### PR TITLE
FFaReference fixup

### DIFF
--- a/src/FFaLib/FFaContainers/FFaFieldContainer.H
+++ b/src/FFaLib/FFaContainers/FFaFieldContainer.H
@@ -154,6 +154,9 @@ protected:
 
   FieldContainerMap myFields;
 
+public:
+  static void removeDictInstance() { FieldContainerDict::removeInstance(); }
+
 private:
   friend class FFaReferenceBase;
 

--- a/src/FFaLib/FFaContainers/FFaReference.C
+++ b/src/FFaLib/FFaContainers/FFaReference.C
@@ -644,6 +644,7 @@ void FFaReferenceBase::setRefAssemblyID(const std::vector<int>& assID)
     IAmResolved = false;
   }
 
+  myUnresolvedRef->resize(2);
   myUnresolvedRef->insert(myUnresolvedRef->end(),assID.begin(),assID.end());
 }
 

--- a/src/FFaLib/FFaDynCalls/FFaSwitchBoard.C
+++ b/src/FFaLib/FFaDynCalls/FFaSwitchBoard.C
@@ -26,6 +26,13 @@ void FFaSwitchBoard::init()
 }
 
 
+void FFaSwitchBoard::removeInstance()
+{
+  delete FFaSwitchBoard::ourConnections;
+  delete FFaSwitchBoard::protectedIterators;
+}
+
+
 // Initialisation of FFaSlotBase0::ourClassTypeID :
 //FFASWB_MAKE_SLOTBASE_ID_INIT_TEMPLATE(0,,)
 

--- a/src/FFaLib/FFaDynCalls/FFaSwitchBoard.H
+++ b/src/FFaLib/FFaDynCalls/FFaSwitchBoard.H
@@ -66,6 +66,7 @@ public:
   static void removeAllSenderConnections(FFaSwitchBoardConnector* sender);
 
   static void init();
+  static void removeInstance();
 
 private:
   static bool isProtected(FFaSlotList::iterator i);


### PR DESCRIPTION
Fixup for commit e0d1ca51a522a976a86e113e210ae5369bef6616.
Any existing assembly ID should be replaced - not appended.
Also added some heap cleanup used by unit test programs only.