### PR TITLE
Minor linkhandler refactoring

### DIFF
--- a/src/FFlLib/FFlConnectorItems.C
+++ b/src/FFlLib/FFlConnectorItems.C
@@ -13,78 +13,79 @@
 
 bool operator== (const FFlConnectorItems& a, const FFlConnectorItems& b)
 {
-  if (&a == &b) return true;
+  if (&a == &b)
+    return true;
 
   if (a.nodes == b.nodes)
     if (a.elements == b.elements)
-      if (a.properties == b.properties)
-	return true;
+      return true;
 
   return false;
 }
 
 
-std::ostream&
-operator<< (std::ostream& s, const FFlConnectorItems& connector)
+std::ostream& operator<< (std::ostream& s, const FFlConnectorItems& c)
 {
-  if (!connector.nodes.empty()) {
+  if (!c.nodes.empty())
+  {
     s <<"\nNODES";
-    for (int n : connector.nodes) s <<' '<< n;
+    for (int n : c.nodes)
+      s <<' '<< n;
   }
-  if (!connector.elements.empty()) {
+
+  if (!c.elements.empty())
+  {
     s <<"\nELEMENTS";
-    for (int e : connector.elements) s <<' '<< e;
+    for (int e : c.elements)
+      s <<' '<< e;
   }
-  if (!connector.properties.empty()) {
-    s <<"\nPROPERTIES";
-    for (int p : connector.properties) s <<' '<< p;
-  }
-  s << std::endl <<"END";
-  return s;
+
+  return s <<"\nEND";
 }
 
 
-std::istream&
-operator>> (std::istream& s, FFlConnectorItems& connector)
+std::istream& operator>> (std::istream& s, FFlConnectorItems& c)
 {
-  connector.clear();
+  // Lambda function reading a vector of integers from the input stream
+  auto&& readStream = [&s](std::vector<int>& data)
+  {
+    while (s)
+    {
+      char c = ' ';
+      while (s && isspace(c))
+        s >> c; // read until next non-space character
+      if (s)
+        s.putback(c);
+      if (!s || !isdigit(c))
+        return; // read until next non-digit character
+
+      int i;
+      s >> i;
+      if (s)
+        data.push_back(i);
+    }
+  };
+
+  c.clear();
   std::string keyWord;
-  while (s.good()) {
+  while (s.good())
+  {
     s >> keyWord;
     bool isAlpha = true;
     for (size_t i = 0; i < keyWord.size() && isAlpha; i++)
       if (!isalpha(keyWord[i]))
         isAlpha = false;
 
-    if (isAlpha) {
+    if (isAlpha)
+    {
       if (keyWord == "NODES")
-	FFlConnectorItems::readStream(s,connector.nodes);
+        readStream(c.nodes);
       else if (keyWord == "ELEMENTS")
-	FFlConnectorItems::readStream(s,connector.elements);
-      else if (keyWord == "PROPERTIES")
-	FFlConnectorItems::readStream(s,connector.properties);
+        readStream(c.elements);
       else if (keyWord == "END")
-	break;
+        break;
     }
   }
+
   return s;
-}
-
-
-void FFlConnectorItems::readStream(std::istream& is, std::vector<int>& data)
-{
-  while (is) {
-    char c = ' ';
-    while (isspace(c)) {
-      is >> c;
-      if (!is) return;
-    }
-    is.putback(c);
-    if (!isdigit(c)) return; // read until next non-digit character
-
-    int i;
-    is >> i;
-    if (is)
-      data.push_back(i);
-  }
 }

--- a/src/FFlLib/FFlConnectorItems.H
+++ b/src/FFlLib/FFlConnectorItems.H
@@ -13,54 +13,30 @@
 
 
 /*!
-  Class FFlConnectorItems is used by FmTriad to store spider connector
-  properties for reading and writing.
-
-  <i>Espen Medbo 2006</i>
+  \brief Storage of spider connector properties for Triads.
 */
 
 class FFlConnectorItems
 {
 public:
-  FFlConnectorItems() {}
-  ~FFlConnectorItems() {}
+  friend bool operator==(const FFlConnectorItems& a, const FFlConnectorItems& b);
 
-  friend bool operator== (const FFlConnectorItems& a,
-			  const FFlConnectorItems& b);
+  friend std::ostream& operator<<(std::ostream& s, const FFlConnectorItems& c);
+  friend std::istream& operator>>(std::istream& s, FFlConnectorItems& c);
 
-  friend  std::ostream& operator<< (std::ostream& s, const FFlConnectorItems& connector);
-  friend  std::istream& operator>> (std::istream& s, FFlConnectorItems& connector);
+  void addNode(int nID) { this->nodes.push_back(nID); }
+  void addElement(int eID) { this->elements.push_back(eID); }
 
-private:
-  static void readStream (std::istream& is, std::vector<int>& data);
+  const std::vector<int>& getNodes() const { return this->nodes; }
+  const std::vector<int>& getElements() const { return this->elements; }
 
-public:
-  void addNode    (int nodeID)     { this->nodes.push_back(nodeID); }
-  void addElement (int elementID)  { this->elements.push_back(elementID); }
-  void addProperty(int propertyID) { this->properties.push_back(propertyID); }
+  bool empty() const { return this->nodes.empty() && this->elements.empty(); }
 
-  const std::vector<int>& getNodes     () const { return this->nodes; }
-  const std::vector<int>& getElements  () const { return this->elements; }
-  const std::vector<int>& getProperties() const { return this->properties; }
-
-  bool empty() const
-  {
-    return this->nodes.empty()
-      &&   this->elements.empty()
-      &&   this->properties.empty();
-  }
-
-  void clear()
-  {
-    this->nodes.clear();
-    this->elements.clear();
-    this->properties.clear();
-  }
+  void clear() { this->nodes.clear(); this->elements.clear(); }
 
 private:
   std::vector<int> nodes;
   std::vector<int> elements;
-  std::vector<int> properties;
 };
 
 #endif

--- a/src/FFlLib/FFlIOAdaptors/FFlAllIOAdaptors.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlAllIOAdaptors.C
@@ -20,8 +20,10 @@ void FFl::initAllReaders()
   FFlOldFLMReader::init();
   FFlNastranReader::init();
   FFlSesamReader::init();
+#ifdef FT_HAS_VKI
   FFlAbaqusReader::init();
   FFlAnsysReader::init();
+#endif
 
   initialized = true;
 }
@@ -29,7 +31,7 @@ void FFl::initAllReaders()
 
 void FFl::releaseAllReaders()
 {
-  FFlReaders::removeInstance ();
+  FFlReaders::removeInstance();
 
   initialized = false;
 }

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -274,16 +274,11 @@ public:
 
   void dump() const;
 
-  FFlNode* createNodeAtPoint(const FaVec3& nodePos, int DOFs = 0);
-
 #ifdef FT_USE_CONNECTORS
   int createConnector(const FFaCompoundGeometry& compound,
                       const FaVec3& nodePos, int spiderType,
                       FFlConnectorItems& cItems);
-
-  int deleteConnectorProperties(const std::vector<int>& propertiesID);
-  int deleteConnectorElements(const std::vector<int>& elementsID);
-  int deleteConnectorNodes(const std::vector<int>& nodesID);
+  int deleteConnector(const FFlConnectorItems& cItems);
 #endif
 
 protected:

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -67,6 +67,8 @@ typedef std::vector<FFlVisualBase*>        VisualsVec;
 typedef VisualsVec::const_iterator         VisualsCIter;
 #endif
 
+typedef std::vector<FFlTypeInfoSpec::Cathegory> CathegoryVec;
+
 typedef std::pair<FFlElementBase*,int> FFlrElement;
 typedef std::vector<FFlrElement>       FFlrElementVec;
 typedef std::vector<FFlrElementVec>    FFlrVxToElmMap;
@@ -195,20 +197,24 @@ public:
 
   void getMassProperties(double& M, FaVec3& Xcg, FFaTensor3& I) const;
 
-  NodesCIter findFreeNodeAtPoint(const FaVec3& point, double tol,
-                                 int dofFilter = -1) const;
-  NodesCIter findClosestNode(const FaVec3& point) const;
+  FFlNode* findFreeNodeAtPoint(const FaVec3& point, double tol,
+                               int dofFilter = -1) const;
+  FFlNode* findClosestNode(const FaVec3& point) const;
 
   FFlNode* createAttachableNode(FFlNode* fromNode, const FaVec3& nodePos,
                                 FFlConnectorItems* cItems = NULL);
 
-  ElementsCIter findClosestElement(const FaVec3& point,
-                                   const std::vector<FFlTypeInfoSpec::Cathegory>&) const;
-  FFlElementBase* findClosestElement(const FaVec3& point, const FFlGroup& group) const;
-  FFlElementBase* findClosestElement(const FaVec3& point, FFlGroup* group = NULL) const;
+  FFlElementBase* findClosestElement(const FaVec3& point,
+                                     const CathegoryVec& wantedTypes) const;
+  FFlElementBase* findClosestElement(const FaVec3& point,
+                                     const FFlGroup& group) const;
+  FFlElementBase* findClosestElement(const FaVec3& point,
+                                     FFlGroup* group = NULL) const;
 
-  FFlElementBase* findPoint(const FFlGroup& group, const FaVec3& point, double* xi) const;
-  FFlElementBase* findPoint(const FaVec3& point, double* xi, int groupID = 0) const;
+  FFlElementBase* findPoint(const FFlGroup& group, const FaVec3& point,
+                            double* xi) const;
+  FFlElementBase* findPoint(const FaVec3& point,
+                            double* xi, int groupID = 0) const;
 
   // Strain coat creation (these methods are defined in FFlStrainCoatCreator.C)
 


### PR DESCRIPTION
Three cosmetic simplifications:
* Let some find-methods searching for nodes or elements in the FE model return a C-pointer to the found object instead of a vector-iterator.
* Remove unused property ID vector in the `FFlConnectorItems` class and merged to remaining methods for deleting elements and nodes into one method `deleteConnector()`.
* Remove method `FFlLinkHandler::createNodeAtPoint()` (replaced by inlined code).