### PR TITLE
Remove unused operators and methods comparing a FFaField with a string

### DIFF
--- a/src/FFaLib/FFaContainers/FFaField.H
+++ b/src/FFaLib/FFaContainers/FFaField.H
@@ -76,33 +76,6 @@ public:
 protected:
   virtual FFaFieldBase* copy(const FFaFieldBase* ref, bool defaultValueToo);
 
-  virtual bool equalTo(const std::string& val) const
-  {
-    ValueT v;
-    this->read(val,v);
-    return myData == v;
-  }
-
-  /* TODO: Implement operator<() for the ValueT class
-  virtual bool lessThan(const std::string& val) const
-  {
-    ValueT v;
-    this->read(val,v);
-    return myData < v;
-  }
-  */
-  virtual bool lessThan(const std::string&) const { return false; }
-
-  /* TODO: Implement operator>() the ValueT class
-  virtual bool greaterThan(const std::string& val) const
-  {
-    ValueT v;
-    this->read(val,v);
-    return myData > v;
-  }
-  */
-  virtual bool greaterThan(const std::string&) const { return false; }
-
   virtual void write(std::ostream& os) const { os << myData; }
   virtual void read(std::istream& is) { this->read(is,myData); }
 

--- a/src/FFaLib/FFaContainers/FFaFieldBase.C
+++ b/src/FFaLib/FFaContainers/FFaFieldBase.C
@@ -11,37 +11,6 @@
 #include "FFaLib/FFaContainers/FFaFieldBase.H"
 
 
-bool operator== (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return lhs.equalTo(rhs);
-}
-
-bool operator!= (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return !lhs.equalTo(rhs);
-}
-
-bool operator>= (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return !lhs.lessThan(rhs);
-}
-
-bool operator<= (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return !lhs.greaterThan(rhs);
-}
-
-bool operator> (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return lhs.greaterThan(rhs);
-}
-
-bool operator< (const FFaFieldBase& lhs, const std::string& rhs)
-{
-  return lhs.lessThan(rhs);
-}
-
-
 std::ostream& operator<< (std::ostream& os, const FFaFieldBase& field)
 {
   field.write(os);

--- a/src/FFaLib/FFaContainers/FFaFieldBase.H
+++ b/src/FFaLib/FFaContainers/FFaFieldBase.H
@@ -40,19 +40,8 @@ protected:
   virtual void write(std::ostream&) const = 0;
   virtual void read(std::istream&) = 0;
 
-  virtual bool equalTo(const std::string&) const = 0;
-  virtual bool lessThan(const std::string&) const = 0;
-  virtual bool greaterThan(const std::string&) const = 0;
-
   friend std::ostream& operator<<(std::ostream&, const FFaFieldBase&);
   friend std::istream& operator>>(std::istream&, FFaFieldBase&);
-
-  friend bool operator==(const FFaFieldBase&, const std::string&);
-  friend bool operator!=(const FFaFieldBase&, const std::string&);
-  friend bool operator>=(const FFaFieldBase&, const std::string&);
-  friend bool operator<=(const FFaFieldBase&, const std::string&);
-  friend bool operator> (const FFaFieldBase&, const std::string&);
-  friend bool operator< (const FFaFieldBase&, const std::string&);
 
   // Helper methods used by some FFaField::write/read instances.
   // Defined in the C-file to avoid excessive recompilation when modified.

--- a/src/FFaLib/FFaContainers/FFaReference.H
+++ b/src/FFaLib/FFaContainers/FFaReference.H
@@ -14,6 +14,9 @@
 class FFaFieldContainer;
 class FFaReferenceListBase;
 
+//! Callback searching for FFaFieldContainer objects when resolving references
+using FFaSearcher = FFaDynCB4<FFaFieldContainer*&,int,int,const IntVec&>;
+
 
 /*!
   \brief Base class for the guarded pointer FFaReference class.
@@ -33,7 +36,7 @@ public:
 
   void setRef(FFaFieldContainer* ptr);
   void setRef(int objId, int typeId);
-  void setRef(int objId, int typeId, const std::vector<int>& assemblyIDs);
+  void setRef(int objId, int typeId, const IntVec& assemblyIDs);
   void setPointerToNull();
 
   void copy(const FFaReferenceBase& aReference, bool unresolve = false);
@@ -54,7 +57,7 @@ public:
   const char* getRefTypeName() const;
   int getRefTypeID() const;
   int getRefID() const;
-  void getRefAssemblyID(std::vector<int>& assID) const;
+  void getRefAssemblyID(IntVec& assID) const;
 
   // IO
 
@@ -65,12 +68,10 @@ public:
   void read(std::istream& is);
 
 protected:
-  void resolve(FFaDynCB4<FFaFieldContainer*&, int, int, const std::vector<int>& >& findCB);
+  void resolve(FFaSearcher& findCB);
   void unresolve();
   void updateAssemblyRef(int from, int to, size_t ind = 0);
-  void updateAssemblyRef(const std::vector<int>& from,
-                         const std::vector<int>& to);
-
+  void updateAssemblyRef(const IntVec& from, const IntVec& to);
   bool isEqual(const FFaReferenceBase* p) const;
 
   void bind();
@@ -93,7 +94,7 @@ private:
 
   void setRefID(int id);
   void setRefTypeID(int id);
-  void setRefAssemblyID(const std::vector<int>& assemblyID);
+  void setRefAssemblyID(const IntVec& assemblyID);
 
   //! Type of unique identification of the unresolved references
   using UnResolvedID = std::vector<int>;
@@ -194,10 +195,8 @@ public:
 };
 
 
-/*!
-  Specialized methods for FFaField to avoid copying and assigning.
-  The pointer value in Fields of Ref pointers are not supposed to change.
-*/
+// Specialized instantiations of FFaField methods.
+// The pointer value in fields of reference pointers is not supposed to change.
 
 using FFaRefPtr = FFaReferenceBase*;
 
@@ -207,16 +206,11 @@ FFaField<FFaRefPtr>::FFaField()
   myData = myDefaultValue = NULL;
 }
 
-template<> inline
-bool FFaField<FFaRefPtr>::isDataField() const
+template<> inline bool
+FFaField<FFaRefPtr>::isDataField() const
 {
   return false;
 }
-
-
-/*!
-  Specialized IO methods for FFaField.
-*/
 
 template<> inline bool
 FFaField<FFaRefPtr>::isPrintable() const
@@ -227,13 +221,13 @@ FFaField<FFaRefPtr>::isPrintable() const
 template<> inline void
 FFaField<FFaRefPtr>::write(std::ostream& os) const
 {
-  myData->write(os);
+  if (myData) myData->write(os);
 }
 
 template<> inline void
 FFaField<FFaRefPtr>::read(std::istream& is, FFaRefPtr& v) const
 {
-  v->read(is);
+  if (v) v->read(is);
 }
 
 #endif

--- a/src/FFaLib/FFaContainers/FFaReferenceList.C
+++ b/src/FFaLib/FFaContainers/FFaReferenceList.C
@@ -5,8 +5,9 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "FFaReferenceList.H"
 #include <cctype>
+
+#include "FFaLib/FFaContainers/FFaReferenceList.H"
 
 
 FFaReferenceListBase::FFaReferenceListBase() : IAmAutoSizing(true)
@@ -237,8 +238,7 @@ void FFaReferenceListBase::getBasePtrs(std::vector<FFaFieldContainer*>& toFill) 
   Used after reading to translate IDs to actual pointers.
 */
 
-void FFaReferenceListBase::resolve(FFaDynCB4<FFaFieldContainer*&,int,int,
-				   const std::vector<int>&>& findCB)
+void FFaReferenceListBase::resolve(FFaSearcher& findCB)
 {
   for (FFaReferenceBase* ref : myRefs)
     ref->resolve(findCB);
@@ -264,8 +264,7 @@ void FFaReferenceListBase::updateAssemblyRef(int from, int to, size_t ind)
 }
 
 
-void FFaReferenceListBase::updateAssemblyRef(const std::vector<int>& from,
-                                             const std::vector<int>& to)
+void FFaReferenceListBase::updateAssemblyRef(const IntVec& from, const IntVec& to)
 {
   for (FFaReferenceBase* ref : myRefs)
     ref->updateAssemblyRef(from,to);
@@ -323,7 +322,7 @@ void FFaReferenceListBase::read(std::istream& is)
   Method used by FFaReferenceBase to notify this container
   (which the FFaReferenceBase object is a member of), that it has been zeroed
   out due to the death of the FFaFieldContainer object it was referring to.
-  Takes the autoSizing mode into account (\sa setAutoSizing),
+  Takes the auto-sizing mode into account (#IAmAutoSizing),
   it either does nothing, or deletes the reference.
 */
 

--- a/src/FFaLib/FFaContainers/FFaReferenceList.H
+++ b/src/FFaLib/FFaContainers/FFaReferenceList.H
@@ -9,7 +9,8 @@
 #define FFA_REFERENCE_LIST_H
 
 #include <list>
-#include "FFaReference.H"
+
+#include "FFaLib/FFaContainers/FFaReference.H"
 
 
 /*!
@@ -83,11 +84,10 @@ private:
 
   void eraseReferenceIfNeeded(FFaReferenceBase* ref);
 
-  void resolve(FFaDynCB4<FFaFieldContainer*&,int,int,const std::vector<int>&>& findCB);
+  void resolve(FFaSearcher& findCB);
   void unresolve();
   void updateAssemblyRef(int from, int to, size_t ind = 0);
-  void updateAssemblyRef(const std::vector<int>& from,
-                         const std::vector<int>& to);
+  void updateAssemblyRef(const IntVec& from, const IntVec& to);
 
   void removePtr (const FFaFieldContainer* ptr, bool notifyContainer);
   void zeroOutPtr(const FFaFieldContainer* ptr, bool notifyContainer);
@@ -207,7 +207,7 @@ public:
   }
 
   //! Replaces the current contents with the provided new references.
-  void setRefs(const std::vector<int>& IDs)
+  void setRefs(const IntVec& IDs)
   {
     this->clear();
     for (int id : IDs)
@@ -307,9 +307,7 @@ private:
 };
 
 
-/*!
-  Specialized methods for FFaField.
-*/
+// Specialized instantiations of FFaField methods.
 
 using FFaRefListPtr = FFaReferenceListBase*;
 
@@ -334,13 +332,13 @@ FFaField<FFaRefListPtr>::isPrintable() const
 template<> inline void
 FFaField<FFaRefListPtr>::write(std::ostream& os) const
 {
-  myData->write(os);
+  if (myData) myData->write(os);
 }
 
 template<> inline void
 FFaField<FFaRefListPtr>::read(std::istream& is, FFaRefListPtr& v) const
 {
-  v->read(is);
+  if (v) v->read(is);
 }
 
 #endif

--- a/src/FFaLib/FFaDefinitions/FFaViewItemUtils.C
+++ b/src/FFaLib/FFaDefinitions/FFaViewItemUtils.C
@@ -34,8 +34,8 @@ bool FFaViewItem::compareDescr(FFaViewItem* i1, FFaViewItem* i2)
   {
     if (i1->getItemID() == 0 && i2->getItemID() == 0)
       return true;
-    else
-      return (i1->getItemID() < i2->getItemID());
+
+    return i1->getItemID() < i2->getItemID();
   }
 
   return stringCompare(s1, s2);
@@ -62,8 +62,8 @@ bool FFaViewItem::compareID(FFaViewItem* i1, FFaViewItem* i2)
 
   if (n1 == n2)
     return stringCompare(i1->getItemDescr(), i2->getItemDescr());
-  else
-    return (n1 < n2);
+
+  return n1 < n2;
 }
 
 
@@ -112,34 +112,10 @@ int FFaViewItem::compareID3w(FFaViewItem* i1, FFaViewItem* i2)
 
   if (id1 < id2)
     return -1;
-  if (id1 > id2)
+  else if (id1 > id2)
     return 1;
-
-  return 0;
-}
-
-
-/*!
-  \brief Case insensitive binary comparison of two characters.
-*/
-
-static bool charCompare(char c1, char c2)
-{
-  int lc1 = tolower(static_cast<unsigned char>(c1));
-  int lc2 = tolower(static_cast<unsigned char>(c2));
-  return lc1 < lc2;
-}
-
-
-/*!
-  \brief Case insensitive three-way comparison of two characters.
-*/
-
-static int charCompare3w(char c1, char c2)
-{
-  int lc1 = tolower(static_cast<unsigned char>(c1));
-  int lc2 = tolower(static_cast<unsigned char>(c2));
-  return lc1 < lc2 ? -1 : (lc1 > lc2 ? 1 : 0);
+  else
+    return 0;
 }
 
 
@@ -149,22 +125,36 @@ static int charCompare3w(char c1, char c2)
 
 static int stringCompare3wImpl(const std::string& s1, const std::string& s2)
 {
-  std::pair<std::string::const_iterator,std::string::const_iterator> p;
-  p = std::mismatch(s1.begin(), s1.end(),
-		    s2.begin(), std::not2(std::ptr_fun(charCompare3w)));
+  // Lambda function doing case-insensitive 3-way comparison of two characters.
+  std::function<int(char,char)> charCompare3w = [](char c1, char c2) -> int
+  {
+    int lc1 = tolower(static_cast<unsigned char>(c1));
+    int lc2 = tolower(static_cast<unsigned char>(c2));
+    return lc1 < lc2 ? -1 : (lc1 > lc2 ? 1 : 0);
+  };
 
+  std::pair<std::string::const_iterator,std::string::const_iterator> p;
+  p = std::mismatch(s1.begin(), s1.end(), s2.begin(), std::not2(charCompare3w));
   if (p.first == s1.end())
     return p.second == s2.end() ? 0 : -1;
-  else
-    return charCompare3w(*p.first,*p.second);
+
+  return charCompare3w(*p.first,*p.second);
 }
 
 
 bool FFaViewItem::stringCompare(const std::string& s1, const std::string& s2)
 {
-  return lexicographical_compare(s1.begin(), s1.end(),
-				 s2.begin(), s2.end(),
-				 std::ptr_fun(charCompare));
+  // Lambda function doing case-insensitive comparison of two characters.
+  std::function<bool(char,char)> charCompare = [](char c1, char c2) -> bool
+  {
+    int lc1 = tolower(static_cast<unsigned char>(c1));
+    int lc2 = tolower(static_cast<unsigned char>(c2));
+    return lc1 < lc2;
+  };
+
+  return std::lexicographical_compare(s1.begin(), s1.end(),
+                                      s2.begin(), s2.end(),
+                                      charCompare);
 }
 
 


### PR DESCRIPTION
The `FFaField::equalTo()` method gives warning on uninitialized variable when instantiated over a `FFaReferenceBase` pointer with newer gcc compilers, and it will crash if this is actually used for `FFaField<FFaReferenceBase*>` since the temporary passed as argument to `read()` is not initialized.