### PR TITLE
Switchboard debug print and fix

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-test:
     name: Build and execute unit tests
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install googletest

--- a/src/FFaLib/FFaAlgebra/FFaVec3.C
+++ b/src/FFaLib/FFaAlgebra/FFaVec3.C
@@ -340,7 +340,7 @@ FaVec3 operator/ (const FaVec3& a, double d)
 {
   if (fabs(d) < EPS_ZERO)
   {
-#if FFA_DEBUG
+#ifdef FFA_DEBUG
     std::cerr <<"FaVec3 operator/(FaVec3&,double): Division by zero, d="<< d
               << std::endl;
 #endif

--- a/src/FFaLib/FFaDynCalls/FFaSwitchBoard.H
+++ b/src/FFaLib/FFaDynCalls/FFaSwitchBoard.H
@@ -17,8 +17,6 @@
 #include <list>
 #include <cstddef>
 
-#include "FFaLib/FFaPatterns/FFaInitialisation.H"
-
 class FFaSlotBase;
 class FFaSwitchBoardConnector;
 
@@ -35,45 +33,40 @@ typedef void(FFaSwitchBoardConnector::*anyMethodType)(...);
 typedef void(*anyFunctionType)(...);
 
 
+////////////////////////////////////////////////////////////////////////////////
 //
 // Static switchboard that holds the connection information
 //
 
-class FFaSwitchBoard
+namespace FFaSwitchBoard
 {
-public:
   // External interface
-  static void connect(FFaSwitchBoardConnector* sender, int subject, FFaSlotBase* slot);
-  static void disConnect(FFaSwitchBoardConnector* sender, int subject, FFaSlotBase* slot);
-  static void removeAllOwnerConnections(FFaSwitchBoardConnector* owner);
+  void connect(FFaSwitchBoardConnector* sender, int subject,
+               FFaSlotBase* slot);
+  void disConnect(FFaSwitchBoardConnector* sender, int subject,
+                  FFaSlotBase* slot);
+  void removeAllOwnerConnections(FFaSwitchBoardConnector* owner);
 
-  // Used internally in SwitchBoard mechanism classes
-  static FFaSlotList& getSlots(FFaSwitchBoardConnector* sender, int subject, unsigned int typeID);
-  static FFaSlotList::iterator nextValidSlot(FFaSlotList::iterator it, FFaSlotList& slots,
-                                             FFaSwitchBoardConnector* sender, int subject);
+  // Used internally in switchboard mechanism classes
+  FFaSlotList& getSlots(FFaSwitchBoardConnector* sender, int subject,
+                        unsigned int typeID);
+  FFaSlotList::iterator nextValidSlot(FFaSlotList::iterator it,
+                                      FFaSlotList& slots,
+                                      FFaSwitchBoardConnector* sender,
+                                      int subject);
   // Used by FFaSlotBase only
-  static void removeSlotReference(FFaSwitchBoardConnector* sender, int subject, FFaSlotBase* slot);
+  void removeSlotReference(FFaSwitchBoardConnector* sender, int subject,
+                           FFaSlotBase* slot);
 
   // Used by FFaSwitchBoardConnector only
-  static void removeAllSenderConnections(FFaSwitchBoardConnector* sender);
+  void removeAllSenderConnections(FFaSwitchBoardConnector* sender);
 
-  static void init();
-  static void removeInstance();
-
-private:
-  static void cleanUpAfterSlot(FFaSwitchBoardConnector* sender, int subject);
-
-  typedef std::map<unsigned int,FFaSlotList>         SlotContainer;
-  typedef std::map<int,SlotContainer>                SlotMap;
-  typedef std::map<FFaSwitchBoardConnector*,SlotMap> SwitchBoardConnection;
-
-  // (Sender, Subject, SlotTypeId) --> List of slots
-  static SwitchBoardConnection* ourConnections;
+  // To clean up the heap-allocated switchboard container
+  void removeInstance();
 };
 
-static FFaInitialisation<FFaSwitchBoard> FFaSwitchBoard_Init;
 
-
+////////////////////////////////////////////////////////////////////////////////
 //
 // Base class for every class that want to send or recieve
 //
@@ -81,7 +74,7 @@ static FFaInitialisation<FFaSwitchBoard> FFaSwitchBoard_Init;
 class FFaSwitchBoardConnector
 {
 public:
-  FFaSwitchBoardConnector(const char* s = NULL) : IAmDeletingMe(false), label(s) {}
+  FFaSwitchBoardConnector(const char* s = NULL);
   virtual ~FFaSwitchBoardConnector();
 
   // Must only be used by FFaSlotN<*>
@@ -108,6 +101,7 @@ private:
 };
 
 
+////////////////////////////////////////////////////////////////////////////////
 //
 // The most basic slot class
 //
@@ -126,8 +120,8 @@ public:
   unsigned int getTypeID() const { return myTypeID; }
 
   // These methods must ONLY be used from FFaSwitchBoard
-  void addConnection(FFaSwitchBoardConnector* sender, int subject);
-  void removeConnection(FFaSwitchBoardConnector* sender, int subject);
+  bool addConnection(FFaSwitchBoardConnector* sender, int subject);
+  bool removeConnection(FFaSwitchBoardConnector* sender, int subject);
 
   // Should be protected, used only by operator==
   virtual FFaSwitchBoardConnector* getObject() = 0;
@@ -146,6 +140,7 @@ private:
 };
 
 
+////////////////////////////////////////////////////////////////////////////////
 //
 // Defines for macro arguments
 //
@@ -199,6 +194,7 @@ private:
 #define FFASWB_PARAM_LIST4 p1, p2, p3, p4
 
 
+////////////////////////////////////////////////////////////////////////////////
 //
 // Macro that defines the different slotBaseN templates.
 // One macro call for each number of arguments we want to support.
@@ -227,6 +223,7 @@ FFASWB_MAKE_SLOTBASE_TEMPLATE(3, FFASWB_TEMPLATE3, FFASWB_ARGUMENT_LIST3, FFASWB
 FFASWB_MAKE_SLOTBASE_TEMPLATE(4, FFASWB_TEMPLATE4, FFASWB_ARGUMENT_LIST4, FFASWB_TYPE_LIST4)
 
 
+////////////////////////////////////////////////////////////////////////////////
 //
 // Macro that defines the different slotN templates
 //
@@ -316,7 +313,7 @@ FFASWB_MAKE_STATIC_SLOT_TEMPLATE(3, FFASWB_TEMPLATE3, FFASWB_ARGUMENT_LIST3, FFA
 FFASWB_MAKE_STATIC_SLOT_TEMPLATE(4, FFASWB_TEMPLATE4, FFASWB_ARGUMENT_LIST4, FFASWB_PARAM_LIST4, FFASWB_TYPE_LIST4)
 
 
-/*!
+/*
   Function to call all the slots connected to a signal.
   Kind of "emit" from the Qt world.
   Loops trough all the slots connected to this signal and invokes them.

--- a/src/FFaLib/FFaPatterns/FFaGenericFactory.H
+++ b/src/FFaLib/FFaPatterns/FFaGenericFactory.H
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#if FFA_DEBUG
+#ifdef FFA_DEBUG
 #include <iostream>
 #endif
 
@@ -22,8 +22,8 @@
 template <class T, class Key = std::string, class ArgType = int>
 class FFaGenericFactory : public FFaSingelton< FFaGenericFactory<T,Key,ArgType> >
 {
-  typedef FFaDynCB2<ArgType,T*&>  CreatorCB;
-  typedef std::map<Key,CreatorCB> CreatorType;
+  using CreatorCB   = FFaDynCB2<ArgType,T*&>;
+  using CreatorType = std::map<Key,CreatorCB>;
 
 public:
   FFaGenericFactory() {}
@@ -31,16 +31,16 @@ public:
 
   bool registerCreator(const Key& key, const CreatorCB& creator)
   {
-    return myCreatorMap.insert(std::make_pair(key,creator)).second;
+    return myCreatorMap.insert({ key, creator }).second;
   }
 
   T* create(const Key& key, ArgType id)
   {
-    T* retVal = 0;
+    T* retVal = NULL;
     typename CreatorType::iterator creator = myCreatorMap.find(key);
     if (creator != myCreatorMap.end())
       creator->second.invoke(id,retVal);
-#if FFA_DEBUG
+#ifdef FFA_DEBUG
     else
       std::cerr <<"\n *** FFaGenericFactory: No creator defined for "
                 << key << std::endl;

--- a/src/FFlLib/CMakeLists.txt
+++ b/src/FFlLib/CMakeLists.txt
@@ -50,7 +50,12 @@ if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
 
-string ( APPEND CMAKE_CXX_FLAGS_DEBUG " -DFFL_DEBUG=2" )
+if ( FT_DEBUG GREATER 12 )
+  math ( EXPR FFL_DEBUG "${FT_DEBUG} - 10" )
+else ( FT_DEBUG GREATER 12 )
+  set ( FFL_DEBUG 2 )
+endif ( FT_DEBUG GREATER 12 )
+string ( APPEND CMAKE_CXX_FLAGS_DEBUG " -DFFL_DEBUG=${FFL_DEBUG}" )
 
 
 # Subfolder handling

--- a/src/FFlLib/FFlLinkHandler.C
+++ b/src/FFlLib/FFlLinkHandler.C
@@ -195,10 +195,10 @@ void FFlLinkHandler::deleteGeometry()
     static_cast<FFlVertex*>(vtx)->unRef();
 #endif
 
-  for (FFlElementBase* e : myElements) delete e;
-  for (FFlNode*        n : myNodes   ) delete n;
   for (const GroupMap::value_type& g : myGroupMap) delete g.second;
   for (FFlLoadBase*    l : myLoads   ) delete l;
+  for (FFlElementBase* e : myElements) delete e;
+  for (FFlNode*        n : myNodes   ) delete n;
 #ifdef FT_USE_VISUALS
   for (FFlVisualBase*  d : myVisuals ) delete d;
 #endif


### PR DESCRIPTION
This (i.e., the last commit) fixes openfedem/fedem-gui#61 when consumed in that repository. There is probably some week logics in the switchboard management used by the GUI, resulting in that a pointer that was deallocated was dereferenced. This happened when deleting a graph objects while its graph view was opened. The fix is to nullify the pointer to the `FFaSlot` object when it is deleted, and then check for null pointer before it is dereferenced elsewhere. Kind of a workaround, as the real problem my be that the FFaSlot containers are inconsistent when adding and removing FFaSlot objects.