### PR TITLE
Small Nastran preader fix and some cleaning

### DIFF
--- a/src/FFaLib/FFaContainers/FFaFieldContainer.H
+++ b/src/FFaLib/FFaContainers/FFaFieldContainer.H
@@ -27,6 +27,11 @@ class FFaFieldContainer : public FFaQueryBase
 {
   Fmd_BASE_HEADER_INIT();
 
+  using IntVec    = std::vector<int>;
+  using FieldMap  = std::map<std::string,FFaFieldBase*>;
+  using ObjectMap = std::multimap<std::string,FFaFieldContainer*>;
+  using ObjectVec = std::vector<FFaFieldContainer*>;
+
 public:
   FFaFieldContainer();
   virtual ~FFaFieldContainer();
@@ -35,14 +40,14 @@ public:
 
   // Field browsing
 
-  void getFields(std::map<std::string,FFaFieldBase*>& mapToFill) const;
+  void getFields(FieldMap& mapToFill) const;
   FFaFieldBase* getField(const std::string& fieldName) const;
 
   // Topology browsing
 
-  void getReferredObjs (std::multimap<std::string,FFaFieldContainer*>& mapToFill) const;
-  void getReferringObjs(std::multimap<std::string,FFaFieldContainer*>& mapToFill) const;
-  void getReferringObjs(std::vector<FFaFieldContainer*>& vecToFill,
+  void getReferredObjs (ObjectMap& mapToFill) const;
+  void getReferringObjs(ObjectMap& mapToFill) const;
+  void getReferringObjs(ObjectVec& vecToFill,
                         const std::string& contextName,
                         bool sortOnId = false) const;
 
@@ -55,7 +60,7 @@ public:
     if (sortOnId)
     {
       // Return the objects in sorted order w.r.t. their user ID
-      std::vector<FFaFieldContainer*> allRefs;
+      ObjectVec allRefs;
       this->getReferringObjs(allRefs,context,sortOnId);
       for (FFaFieldContainer* ref : allRefs)
         if ((ptr = dynamic_cast<T*>(ref)))
@@ -65,8 +70,8 @@ public:
     {
       // Return the objects in arbitrary order
       // (might be different in two runs of the same problem).
-      FFaFieldContainer* ref = this->getNextReferringObj(context,true);
-      for (ptr = NULL; ref; ref = this->getNextReferringObj(context))
+      FFaFieldContainer* ref = this->getNext(context,true);
+      for (ptr = NULL; ref; ref = this->getNext(context))
         if ((ptr = dynamic_cast<T*>(ref)))
           vecToFill.push_back(ptr);
     }
@@ -77,8 +82,8 @@ public:
   template<class T>
   bool hasReferringObjs(T*& ptr, const std::string& context = "") const
   {
-    FFaFieldContainer* ref = this->getNextReferringObj(context,true);
-    for (ptr = NULL; ref; ref = this->getNextReferringObj(context))
+    FFaFieldContainer* ref = this->getNext(context,true);
+    for (ptr = NULL; ref; ref = this->getNext(context))
       if ((ptr = dynamic_cast<T*>(ref)))
         return true;
     return false;
@@ -89,9 +94,11 @@ public:
   void releaseReferencesToMe(const std::string& contextName = "",
                              FFaFieldContainer* replacement = NULL);
 
+  using FindCB = FFaDynCB4<FFaFieldContainer*&,int,int,const IntVec&>;
+
   // Methods for resolving of FFaReference and FFaReferenceList after reading
 
-  void resolve(FFaDynCB4<FFaFieldContainer*&,int,int,const std::vector<int>&>& findCB);
+  void resolve(FindCB& findCB);
   void unresolve();
 
   // Method for initializing fields after resolve
@@ -101,13 +108,12 @@ public:
   // Method returning the ID number and assemblyIDs used in IO and resolving
 
   virtual int getResolvedID() const { return -1; }
-  virtual void getResolvedAssemblyID(std::vector<int>&) const {}
+  virtual void getResolvedAssemblyID(IntVec&) const {}
 
   // Methods updating the assemblyID in references in this object.
 
   void updateReferences(int oldAssId, int newAssId);
-  void updateReferences(const std::vector<int>& oldAssId,
-                        const std::vector<int>& newAssID);
+  void updateReferences(const IntVec& oldAssId, const IntVec& newAssID);
 
   // Method for reading the value of a named field from an input stream
 
@@ -130,8 +136,8 @@ protected:
   // Methods to add guarded pointers to other FFaFieldContainers
   // into the internal book keeping
 
-  void addRef(FFaReferenceBase* ref, bool isDynamic = false);
-  void addRefList(FFaReferenceListBase* list, bool isDynamic = false);
+  void addRef(FFaReferenceBase* ref);
+  void addRefList(FFaReferenceListBase* list);
 
   // Methods to add and remove read/writable fields of "any" type
   // to/from the internal book keeping
@@ -168,8 +174,8 @@ private:
 
   // Helper method to loop over all objects referring to this
 
-  FFaFieldContainer* getNextReferringObj(const std::string& context,
-                                         bool getFirst = false) const;
+  FFaFieldContainer* getNext(const std::string& context,
+                             bool getFirst = false) const;
 
   // The internal book keeping of who is pointing to whom
 
@@ -178,11 +184,6 @@ private:
   ReferenceSet                     myRefBy;
   std::list<FFaReferenceBase*>     myRefTo;
   std::list<FFaReferenceListBase*> myRefLists;
-
-  // Keep track of what to delete when destructing
-
-  std::list<FFaReferenceBase*>     myDynamicRefs;
-  std::list<FFaReferenceListBase*> myDynamicRefLists;
 };
 
 

--- a/src/FFaLib/FFaContainers/FFaReference.C
+++ b/src/FFaLib/FFaContainers/FFaReference.C
@@ -293,7 +293,7 @@ void FFaReferenceBase::resolve(FFaSearcher& findCB)
   else
   {
     FFaFieldContainer* owner = this->getOwnerFieldContainer();
-    std::cerr <<"FFaReferenceBase::resolve: Resolve failure (TypeID="
+    std::cerr <<"FFaReferenceBase::resolve(): Resolve failure (TypeID="
               << typeID <<" "<< FFaTypeCheck::getTypeNameFromID(typeID)
               <<", ID="<< this->getRefID();
     if (!assID.empty())
@@ -317,7 +317,7 @@ void FFaReferenceBase::resolve(FFaSearcher& findCB)
 #if FFA_DEBUG > 1
   FFaFieldContainer* ofc = this->getOwnerFieldContainer();
   if (ofc && this->getRef())
-    std::cout <<"FFaReferenceBase: "<< this->getContextName()
+    std::cout <<"FFaReferenceBase::resolve():  "<< this->getContextName()
               <<" in " << ofc->getTypeIDName() <<" "<< ofc->getResolvedID()
               <<" resolved to "<< foundObj->getTypeIDName()
               <<" "<< foundObj->getResolvedID() << std::endl;
@@ -337,9 +337,9 @@ void FFaReferenceBase::unresolve()
 #ifdef FFA_DEBUG
   FFaFieldContainer* ofc = this->getOwnerFieldContainer();
   if (ofc)
-    std::cout <<"FFaReferenceBase: "<< this->getContextName() <<" in "
-              << ofc->getTypeIDName() <<" "<< ofc->getResolvedID()
-              <<" unresolved"<< std::endl;
+    std::cout <<"FFaReferenceBase::unresolve(): "<< this->getContextName()
+              <<" in " << ofc->getTypeIDName() <<" "<< ofc->getResolvedID()
+              << std::endl;
 #endif
 
   UnResolvedID* uResRef = new UnResolvedID({ myPtr->getTypeID(), myPtr->getResolvedID() });
@@ -585,8 +585,21 @@ void FFaReferenceBase::copy(const FFaReferenceBase& aRef, bool unresolve)
     aRef.getRefAssemblyID(*myUnresolvedRef);
     IAmResolved = false;
   }
+  else if (aRef.isNull())
+    this->setRef(NULL);
   else
+  {
     this->setRef(aRef.getRef());
+#if FFA_DEBUG > 1
+    std::cout <<"FFaReferenceBase::copy(): "
+              << this->getRefTypeName() <<" ["<< this->getRefID() <<"] "
+              << aRef.getContextName() <<" to "<< this->getContextName();
+    FFaFieldContainer* ofc = this->getOwnerFieldContainer();
+    if (ofc)
+      std::cout <<" in "<< ofc->getTypeIDName() <<" "<< ofc->getResolvedID();
+    std::cout << std::endl;
+#endif
+  }
 }
 
 

--- a/src/FFlLib/FFlIOAdaptors/FFlNastranProcessor.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlNastranProcessor.C
@@ -72,34 +72,6 @@ namespace FF_NAMESPACE {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static FFlAttributeBase* createBeamSection (int PID, FFlCrossSection& data,
-                                            std::pair<int,std::string>& comment)
-{
-  FFlPBEAMSECTION* myAtt = CREATE_ATTRIBUTE(FFlPBEAMSECTION,"PBEAMSECTION",PID);
-  myAtt->crossSectionArea = round(data.A,10);
-  myAtt->phi = round(data.findMainAxes(),10);
-  myAtt->Iy  = round(data.Izz,10);
-  myAtt->Iz  = round(data.Iyy,10);
-  myAtt->It  = round(data.J,10);
-  myAtt->Kxy = round(data.K1,10);
-  myAtt->Kxz = round(data.K2,10);
-  myAtt->Sy  = round(data.S1,10);
-  myAtt->Sz  = round(data.S2,10);
-
-  if (comment.first > 0)
-    // Set property name from the first comment line before this PBEAM entry
-    if (FFlNastranReader::extractNameFromComment(comment.second,true))
-      myAtt->setName(comment.second);
-
-#ifdef FFL_DEBUG
-  std::cout << data;
-  myAtt->print();
-#endif
-  return myAtt;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 static FFlAttributeBase* createNSM (int PID, double NSM, bool isShell = false)
 {
   FFlPNSM* myAtt = CREATE_ATTRIBUTE(FFlPNSM,"PNSM",PID);
@@ -1153,8 +1125,7 @@ bool FFlNastranReader::process_CONROD (std::vector<std::string>& entry)
 	    << std::endl;
 #endif
 
-  this->insertBeamPropMat("PROD",EID,MID);
-  myLink->addAttribute(createBeamSection(EID,params,lastComment));
+  this->createBeamSection("PROD",EID,MID,params);
 
   if (params.NSM != 0.0)
   {
@@ -2317,13 +2288,7 @@ bool FFlNastranReader::process_MAT1 (std::vector<std::string>& entry)
   myAtt->poissonsRatio   = round(NU,10);
   myAtt->materialDensity = round(RHO,10);
 
-  if (lastComment.first > 0)
-    if (extractNameFromComment(lastComment.second))
-      myAtt->setName(lastComment.second);
-
-#ifdef FFL_DEBUG
-  myAtt->print();
-#endif
+  this->nameFromLastComment(myAtt);
   myLink->addAttribute(myAtt);
 
   STOPP_TIMER("process_MAT1")
@@ -2372,13 +2337,7 @@ bool FFlNastranReader::process_MAT2 (std::vector<std::string>& entry)
     myAtt->C[i] = round(C[i],10);
   myAtt->materialDensity = round(RHO,10);
 
-  if (lastComment.first > 0)
-    if (extractNameFromComment(lastComment.second))
-      myAtt->setName(lastComment.second);
-
-#ifdef FFL_DEBUG
-  myAtt->print();
-#endif
+  this->nameFromLastComment(myAtt);
   myLink->addAttribute(myAtt);
 
   STOPP_TIMER("process_MAT2")
@@ -2434,13 +2393,7 @@ bool FFlNastranReader::process_MAT8 (std::vector<std::string>& entry)
   myAtt->G2Z  = round(G2Z,10);
   myAtt->materialDensity = round(RHO,10);
 
-  if (lastComment.first > 0)
-    if (extractNameFromComment(lastComment.second))
-      myAtt->setName(lastComment.second);
-
-#ifdef FFL_DEBUG
-  myAtt->print();
-#endif
+  this->nameFromLastComment(myAtt);
   myLink->addAttribute(myAtt);
 
   STOPP_TIMER("process_MAT8")
@@ -2490,13 +2443,7 @@ bool FFlNastranReader::process_MAT9 (std::vector<std::string>& entry)
     myAtt->C[i] = round(C[i],10);
   myAtt->materialDensity = round(RHO,10);
 
-  if (lastComment.first > 0)
-    if (extractNameFromComment(lastComment.second))
-      myAtt->setName(lastComment.second);
-
-#ifdef FFL_DEBUG
-  myAtt->print();
-#endif
+  this->nameFromLastComment(myAtt);
   myLink->addAttribute(myAtt);
 
   STOPP_TIMER("process_MAT9")
@@ -2712,8 +2659,7 @@ bool FFlNastranReader::process_PBAR (std::vector<std::string>& entry)
 	    << std::endl;
 #endif
 
-  this->insertBeamPropMat("PBAR",PID,MID);
-  myLink->addAttribute(createBeamSection(PID,params,lastComment));
+  this->createBeamSection("PBAR",PID,MID,params);
 
   if (params.NSM != 0.0)
   {
@@ -2796,10 +2742,7 @@ bool FFlNastranReader::process_PBARL (std::vector<std::string>& entry)
 
   FFlCrossSection params(Type,Dim);
   if (params.A > 0.0)
-  {
-    this->insertBeamPropMat("PBARL",PID,MID);
-    myLink->addAttribute(createBeamSection(PID,params,lastComment));
-  }
+    this->createBeamSection("PBARL",PID,MID,params);
   else
     ListUI <<"            Error occurred when processing PBARL "<< PID <<".\n";
 
@@ -2948,8 +2891,7 @@ bool FFlNastranReader::process_PBEAM (std::vector<std::string>& entry)
 	    << std::endl;
 #endif
 
-  this->insertBeamPropMat("PBEAM",PID,MID);
-  myLink->addAttribute(createBeamSection(PID,params,lastComment));
+  this->createBeamSection("PBEAM",PID,MID,params);
 
   if (params.NSM != 0.0)
   {
@@ -3054,10 +2996,7 @@ bool FFlNastranReader::process_PBEAML (std::vector<std::string>& entry)
 
   FFlCrossSection params(Type,Dim);
   if (params.A > 0.0)
-  {
-    this->insertBeamPropMat("PBEAML",PID,MID);
-    myLink->addAttribute(createBeamSection(PID,params,lastComment));
-  }
+    this->createBeamSection("PBEAML",PID,MID,params);
   else
     ListUI <<"            Error occurred when processing PBEAML "<< PID <<".\n";
 
@@ -3125,10 +3064,7 @@ bool FFlNastranReader::process_PBUSH (std::vector<std::string>& entry)
   FFlPBUSHCOEFF* myAtt = CREATE_ATTRIBUTE(FFlPBUSHCOEFF,"PBUSHCOEFF",PID);
   for (i = 0; i < 6; i++) myAtt->K[i] = round(K[i],10);
 
-  if (lastComment.first > 0)
-    if (extractNameFromComment(lastComment.second))
-      myAtt->setName(lastComment.second);
-
+  this->nameFromLastComment(myAtt);
   myLink->addAttribute(myAtt);
 
   STOPP_TIMER("process_PBUSH")
@@ -3359,8 +3295,7 @@ bool FFlNastranReader::process_PROD (std::vector<std::string>& entry)
 	    << std::endl;
 #endif
 
-  this->insertBeamPropMat("PROD",PID,MID);
-  myLink->addAttribute(createBeamSection(PID,params,lastComment));
+  this->createBeamSection("PROD",PID,MID,params);
 
   if (params.NSM != 0.0)
   {
@@ -3438,13 +3373,7 @@ bool FFlNastranReader::process_PSHELL (std::vector<std::string>& entry)
              <<"            This may result in a singular stiffness matrix.\n";
     }
 
-    if (lastComment.first > 0)
-      if (extractNameFromComment(lastComment.second))
-	myAtt->setName(lastComment.second);
-
-#ifdef FFL_DEBUG
-    myAtt->print();
-#endif
+    this->nameFromLastComment(myAtt);
     myLink->addAttribute(myAtt);
     PTHICKs.insert(PID);
   }
@@ -3525,10 +3454,8 @@ bool FFlNastranReader::process_PWELD (std::vector<std::string>& entry)
 	    << std::endl;
 #endif
 
-  this->insertBeamPropMat("PWELD",PID,MID);
-
   FFlCrossSection params("ROD",{0.5*D});
-  myLink->addAttribute(createBeamSection(PID,params,lastComment));
+  this->createBeamSection("PWELD",PID,MID,params);
 
   STOPP_TIMER("process_PWELD")
   return true;
@@ -4048,7 +3975,8 @@ bool FFlNastranReader::process_SPC1 (std::vector<std::string>& entry)
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-bool FFlNastranReader::insertBeamPropMat (const char* bulk, int PID, int MID)
+bool FFlNastranReader::createBeamSection (const char* bulk, int PID, int MID,
+                                          FFlCrossSection& data)
 {
   IntMap& beamMID = propMID[FFlTypeInfoSpec::BEAM_ELM];
 
@@ -4070,6 +3998,36 @@ bool FFlNastranReader::insertBeamPropMat (const char* bulk, int PID, int MID)
     return false;
   }
 
+  FFlPBEAMSECTION* myAtt = CREATE_ATTRIBUTE(FFlPBEAMSECTION,"PBEAMSECTION",PID);
+  myAtt->crossSectionArea = round(data.A,10);
+  myAtt->phi = round(data.findMainAxes(),10);
+  myAtt->Iy  = round(data.Izz,10);
+  myAtt->Iz  = round(data.Iyy,10);
+  myAtt->It  = round(data.J,10);
+  myAtt->Kxy = round(data.K1,10);
+  myAtt->Kxz = round(data.K2,10);
+  myAtt->Sy  = round(data.S1,10);
+  myAtt->Sz  = round(data.S2,10);
+#ifdef FFL_DEBUG
+  std::cout << data;
+#endif
+
+  // Set property name from the first comment line before this PBEAM entry
+  this->nameFromLastComment(myAtt,true);
+  return myLink->addAttribute(myAtt);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool FFlNastranReader::nameFromLastComment (FFlAttributeBase* att, bool first)
+{
+  if (!att || lastComment.first < 1 || !this->extractNameFromLastComment(first))
+    return false;
+
+  att->setName(lastComment.second);
+#ifdef FFL_DEBUG
+  att->print();
+#endif
   return true;
 }
 

--- a/src/FFlLib/FFlIOAdaptors/FFlNastranReader.C
+++ b/src/FFlLib/FFlIOAdaptors/FFlNastranReader.C
@@ -302,7 +302,13 @@ bool FFlNastranReader::read (std::istream& is)
   bool stillOK = procOK = true;
   while (sizeOK && (stillOK = this->getNextEntry(is,entry)))
     if (entry.name == endOfBulk)
+    {
+      // In case the last bulk data entry in the file is a group definition
+      // we need to check if it is named here, before exiting
+      this->nameFromLastComment(lastGroup,true);
+      lastGroup = NULL;
       break;
+    }
     else if (!entry.cont.empty())
       ucEntries.push_back(entry);
     else if (!this->processThisEntry(entry))
@@ -840,15 +846,7 @@ int FFlNastranReader::getNextField (std::istream& is, std::string& field,
 
 bool FFlNastranReader::processThisEntry (BulkEntry& entry)
 {
-  if (lastGroup && lastComment.first &&
-      extractNameFromComment(lastComment.second,true))
-  {
-#if FFL_DEBUG > 2
-    std::cout <<"Element group "<< lastGroup->getID()
-              <<" is named \""<< lastComment.second <<"\""<< std::endl;
-#endif
-    lastGroup->setName(lastComment.second);
-  }
+  this->nameFromLastComment(lastGroup,true);
   lastGroup = NULL;
 
   START_TIMER("processThisEntry")
@@ -913,8 +911,7 @@ bool FFlNastranReader::processAllSets (std::istream& fs, const int startBulk)
         else
         {
           // Check if the group was named after the group definition itself
-          if (lastComment.first && extractNameFromComment(lastComment.second))
-            aGroup->setName(lastComment.second);
+          this->nameFromLastComment(aGroup);
           myLink->addGroup(aGroup); // Add element group to the FE model
         }
         aGroup = NULL;
@@ -951,7 +948,7 @@ bool FFlNastranReader::processAllSets (std::istream& fs, const int startBulk)
 
       // Check if the group is named before the group definition itself
       else if (lastComment.first > 0 && lastComment.first < startLin &&
-               extractNameFromComment(lastComment.second))
+               this->extractNameFromLastComment())
       {
         aGroup->setName(lastComment.second);
         myLink->addGroup(aGroup);
@@ -971,8 +968,7 @@ bool FFlNastranReader::processAllSets (std::istream& fs, const int startBulk)
     else
     {
       // Check if the group was named after the group definition itself
-      if (lastComment.first && extractNameFromComment(lastComment.second))
-        aGroup->setName(lastComment.second);
+      this->nameFromLastComment(aGroup);
       myLink->addGroup(aGroup);
     }
     lastComment = { 0, "" };
@@ -1149,9 +1145,23 @@ void FFlNastranReader::processAssignFile (const std::string& line)
 }
 
 
-bool FFlNastranReader::extractNameFromComment (std::string& commentLine,
-					       bool first)
+bool FFlNastranReader::nameFromLastComment (FFlGroup* group, bool first)
 {
+  if (!group || !lastComment.first || !this->extractNameFromLastComment(first))
+    return false;
+
+#if FFL_DEBUG > 2
+  std::cout <<"Element group "<< group->getID()
+            <<" is named \""<< lastComment.second <<"\""<< std::endl;
+#endif
+  group->setName(lastComment.second);
+  return true;
+}
+
+
+bool FFlNastranReader::extractNameFromLastComment (bool first)
+{
+  std::string& commentLine = lastComment.second;
 #if FFL_DEBUG > 1
   std::cout <<"FFlNastranReader: Processing comment\n"<< commentLine;
 #endif

--- a/src/FFlLib/FFlIOAdaptors/FFlNastranReader.H
+++ b/src/FFlLib/FFlIOAdaptors/FFlNastranReader.H
@@ -20,6 +20,7 @@
 
 #define DEF_PROCESSOR(rec) bool process_##rec (std::vector<std::string>& entry);
 
+class FFlCrossSection;
 class FFaCheckSum;
 
 #ifdef FF_NAMESPACE
@@ -155,9 +156,6 @@ public:
   static void identifierCB (const std::string& fileName, int& positiveIdent);
   static void readerCB     (const std::string& fileName, FFlLinkHandler* link);
 
-  static bool extractNameFromComment (std::string& commentLine,
-                                      bool first = false);
-
 protected:
 
   bool read (const std::string& fileName, bool includedFile = false);
@@ -172,6 +170,12 @@ protected:
   bool processAllSets (std::istream& fs, const int startBulk);
   FFlGroup* processThisSet (std::string& setLine,
 			    const int startL, const int stopL);
+
+  bool extractNameFromLastComment (bool first = false);
+  // Extract element group name from the last comment read
+  bool nameFromLastComment (FFlGroup* group, bool first = false);
+  // Extract attribute name from the last comment read
+  bool nameFromLastComment (FFlAttributeBase* att, bool first = false);
 
   // Read next bulk-entry from the input stream
   bool getNextEntry (std::istream& is, BulkEntry& entry);
@@ -220,7 +224,8 @@ protected:
   bool processThisEntry (const std::string& name,
 			 std::vector<std::string>& entry);
 
-  bool insertBeamPropMat (const char* bulk, int PID, int MID);
+  bool createBeamSection (const char* bulk, int PID, int MID,
+                          FFlCrossSection& data);
 
   IntMap::iterator setDofFlag (int n, int flg);
 

--- a/src/FFlLib/FFlLinkHandler.C
+++ b/src/FFlLib/FFlLinkHandler.C
@@ -211,15 +211,18 @@ void FFlLinkHandler::deleteGeometry()
   myElements.clear();
   myFElements.clear();
   myBushElements.clear();
+  myOP2files.clear();
   myNodes.clear();
   myFEnodes.clear();
 #ifdef FT_USE_VERTEX
   myVertices.clear();
+  myVxMapping.clear();
 #endif
   myGroupMap.clear();
   myLoads.clear();
   myAttributes.clear();
   uniqueAtts.clear();
+  myNodeMapping.clear();
 #ifdef FT_USE_VISUALS
   myVisuals.clear();
 #endif
@@ -235,6 +238,7 @@ void FFlLinkHandler::deleteGeometry()
   areVisualsSorted = true;
 #endif
 
+  nGenDofs = 0;
   isResolved = true;
 }
 
@@ -726,6 +730,7 @@ FFlNode* FFlLinkHandler::getFENode(int inod) const
 {
   if (inod <= 0) return NULL;
 
+  size_t idx = inod-1;
   if (hasLooseNodes)
   {
     if (myFEnodes.empty())
@@ -743,11 +748,11 @@ FFlNode* FFlLinkHandler::getFENode(int inod) const
         return NULL;
     }
 
-    if ((size_t)inod <= myFEnodes.size())
-      return myFEnodes[inod-1];
+    if (idx < myFEnodes.size())
+      return myFEnodes[idx];
   }
-  else if ((size_t)inod <= myNodes.size())
-    return myNodes[inod-1]; // Assuming no loose nodes exist!
+  else if (idx < myNodes.size())
+    return myNodes[idx]; // Assuming no loose nodes exist!
 
   return NULL;
 }
@@ -807,8 +812,8 @@ FFlLinkHandler::ElementsIter FFlLinkHandler::getElementIter(int ID) const
 
 FFlElementBase* FFlLinkHandler::getElement(int ID, bool internalID) const
 {
-  if (internalID)
-    return ID >= 0 && (size_t)ID < myElements.size() ? myElements[ID] : NULL;
+  if (internalID && ID >= 0)
+    return ID < static_cast<int>(myElements.size()) ? myElements[ID] : NULL;
 
   ElementsIter eit = this->getElementIter(ID);
   return eit == myElements.end() ? NULL : *eit;
@@ -909,7 +914,7 @@ FFlElementBase* FFlLinkHandler::getFiniteElement(int iel) const
     if (this->buildFiniteElementVec() < 1)
       return NULL;
 
-  return (size_t)iel <= myFElements.size() ? myFElements[iel-1] : NULL;
+  return --iel < static_cast<int>(myFElements.size()) ? myFElements[iel] : NULL;
 }
 
 
@@ -963,7 +968,7 @@ const AttributeMap& FFlLinkHandler::getAttributes(const std::string& type) const
   which are not connected to other elements than the spider itself.
 */
 
-bool FFlLinkHandler::getRefNodes(std::vector<FFlNode*>& refNodes) const
+bool FFlLinkHandler::getRefNodes(NodesVec& refNodes) const
 {
   refNodes.clear();
   if (myNodes.empty())
@@ -1731,6 +1736,28 @@ FFlElementBase* FFlLinkHandler::findPoint(const FaVec3& point, double* xi,
 }
 
 
+FFlNode* FFlLinkHandler::getNodeConnectivity(int ID, Strings& elmList) const
+{
+  NodesIter nit = this->getNodeIter(ID);
+  if (nit == myNodes.end()) return NULL;
+
+  if (myNodeMapping.empty())
+    for (FFlElementBase* elm : myElements)
+      for (NodeCIter n = elm->nodesBegin(); n != elm->nodesEnd(); ++n)
+        myNodeMapping[n->getReference()].insert(elm);
+
+  std::map<FFlNode*,ElementsSet>::const_iterator cit = myNodeMapping.find(*nit);
+  if (cit == myNodeMapping.end() || cit->second.empty()) return NULL;
+
+  elmList.clear();
+  elmList.reserve(cit->second.size());
+  for (FFlElementBase* elm : cit->second)
+    elmList.push_back(elm->getTypeName() + " " + std::to_string(elm->getID()));
+
+  return *nit;
+}
+
+
 #ifdef FT_USE_VERTEX
 FFlVertex* FFlLinkHandler::getVertex(size_t i) const
 {
@@ -1958,7 +1985,7 @@ bool FFlLinkHandler::resolve(bool subdivParabolic, bool fromSESAM)
       // Find all dependent nodes that are connected to other elements
       int looseDn = 0;
       NodeCIter n = elm->nodesBegin();
-      std::vector<FFlNode*> depNodes;
+      NodesVec depNodes;
       depNodes.reserve(nNod-1);
       for (++n; n != elm->nodesEnd(); ++n)
         if ((*n)->hasDOFs())
@@ -2354,7 +2381,7 @@ int FFlLinkHandler::createConnector(const FFaCompoundGeometry& compound,
   if (spiderType < 2 || spiderType > 3)
     return -1; // Invalid spider type
 
-  std::vector<FFlNode*> nodes;
+  NodesVec nodes;
   for (FFlNode* node : myNodes)
     if (node->hasDOFs() && node->getStatus() == FFlNode::INTERNAL)
       if (compound.isInside(node->getPos()))

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -134,7 +134,7 @@ public:
   FFlVAppearance*   getAppearance(int ID) const;
 #endif
 
-  bool getRefNodes(std::vector<FFlNode*>& refNodes) const;
+  bool getRefNodes(NodesVec& refNodes) const;
   bool getLoads(int ID, LoadsVec& loads) const;
   void getLoadCases(std::set<int>& IDs) const;
 
@@ -235,6 +235,10 @@ public:
   FFlElementBase* findPoint(const FaVec3& point,
                             double* xi, int groupID = 0) const;
 
+  using Strings = std::vector<std::string>;
+  //! \brief Returns the list of elements connected to the specified node \a ID.
+  FFlNode* getNodeConnectivity(int ID, Strings& elmList) const;
+
   // Strain coat creation (these methods are defined in FFlStrainCoatCreator.C)
 
   bool makeStrainCoat(FFlFaceGenerator* geometry,
@@ -288,7 +292,7 @@ public:
   void addComponentModes(int nGen) { nGenDofs += nGen; }
   void addOP2file(const std::string& fname) { myOP2files.push_back(fname); }
   void clearOP2files() { myOP2files.clear(); }
-  const std::vector<std::string>& getOP2files() const { return myOP2files; }
+  const Strings& getOP2files() const { return myOP2files; }
   size_t getNumberOfGenDofs() const { return nGenDofs; }
 
   void dump() const;
@@ -350,6 +354,7 @@ protected:
   AttributeTypeMap      myAttributes;
 
   std::map<unsigned int,FFlAttributeBase*> uniqueAtts;
+  mutable std::map<FFlNode*,ElementsSet>   myNodeMapping;
 
   bool                  isResolved;    // Flag to avoid resolving more than once
   bool                  hasLooseNodes; // true if unconnected nodes are present
@@ -358,7 +363,7 @@ protected:
   mutable ElmTypeCount  myNumElements; // the number of elements of each type
   mutable ElementsVec   myFElements;   // pointers to the Finite Elements only
   mutable ElementsSet   myBushElements;// pointers to the BUSH elements only
-  std::vector<std::string> myOP2files; // files with externally reduced matrices
+  Strings               myOP2files;    // files with externally reduced matrices
   size_t                nGenDofs;      // as read from Nastran bulk data file
 
   mutable FFaCheckSum*  myChkSum;


### PR DESCRIPTION
The first commit removes an unused/non-finished feature in the FFaFieldContainer class.
The second commit accounts for Nastran SET1 entries at the end of the bulk data with the set name just before ENDDATA.
The third commit adds a method for extracting the list of elements connected to a specified node.