### PR TITLE
Small FFa3DLocation update

### DIFF
--- a/src/FFaLib/FFaAlgebra/FFa3DLocation.C
+++ b/src/FFaLib/FFaAlgebra/FFa3DLocation.C
@@ -13,15 +13,11 @@
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
 
 
-/*!
-  Constructors.
-*/
-
-FFa3DLocation::FFa3DLocation(bool saveNumericalData)
+FFa3DLocation::FFa3DLocation(bool saveNumData)
 {
   myPosTyp = CART_X_Y_Z;
   myRotTyp = EUL_Z_Y_X;
-  saveMyNumericalData = saveNumericalData;
+  saveNumericalData = saveNumData;
 }
 
 FFa3DLocation::FFa3DLocation(PosType t, const FaVec3& v0,
@@ -32,7 +28,7 @@ FFa3DLocation::FFa3DLocation(PosType t, const FaVec3& v0,
   myL[0] = v0;
   myL[1] = v1;
   myL[2] = v2;
-  saveMyNumericalData = true;
+  saveNumericalData = true;
 }
 
 FFa3DLocation::FFa3DLocation(PosType t, const FaVec3& v0,
@@ -42,7 +38,7 @@ FFa3DLocation::FFa3DLocation(PosType t, const FaVec3& v0,
   myRotTyp = r;
   myL[0] = v0;
   myL[1] = v1;
-  saveMyNumericalData = true;
+  saveNumericalData = true;
 
   if (this->getNumFields() == 9)
     std::cerr <<"FFa3DLocation constructor: Second rotation definition vector "
@@ -56,7 +52,7 @@ FFa3DLocation::FFa3DLocation(const FaMat34& m)
   myL[0] = m[3];
   myL[1] = m[0];
   myL[2] = m[1];
-  saveMyNumericalData = true;
+  saveNumericalData = true;
 }
 
 
@@ -74,7 +70,7 @@ FFa3DLocation& FFa3DLocation::operator= (const FFa3DLocation& m)
   myL[0] = m.myL[0];
   myL[1] = m.myL[1];
   myL[2] = m.myL[2];
-  // JJS: Note that saveMyNumericalData is NOT copied.
+  // JJS: Note that saveNumericalData is NOT copied.
   // That is meta data valid for one particular instance only.
   return *this;
 }
@@ -86,9 +82,9 @@ FFa3DLocation& FFa3DLocation::operator= (const FaMat34& m)
 }
 
 
-bool FFa3DLocation::isCoincident(const FFa3DLocation& m, double tol) const
+bool FFa3DLocation::isCoincident(const FFa3DLocation& m) const
 {
-  return this->getMatrix().isCoincident(m.getMatrix(),tol);
+  return this->getMatrix().isCoincident(m.getMatrix(),1.0e-7);
 }
 
 
@@ -96,12 +92,13 @@ bool FFa3DLocation::isCoincident(const FFa3DLocation& m, double tol) const
   Converts the position representation in \a *this to the provided type.
 */
 
-FFa3DLocation& FFa3DLocation::changePosType(PosType newType)
+bool FFa3DLocation::changePosType(PosType newType)
 {
-  if (newType != myPosTyp)
-    this->setPos(newType, this->translation());
+  if (newType == myPosTyp) return false;
 
-  return *this;
+  this->setPos(newType, this->translation());
+
+  return true;
 }
 
 
@@ -109,12 +106,13 @@ FFa3DLocation& FFa3DLocation::changePosType(PosType newType)
   Converts the rotational representation in \a *this to the provided type.
 */
 
-FFa3DLocation& FFa3DLocation::changeRotType(RotType newType)
+bool FFa3DLocation::changeRotType(RotType newType)
 {
-  if (newType != myRotTyp)
-    this->setRot(newType, this->direction());
+  if (newType == myRotTyp) return false;
 
-  return *this;
+  this->setRot(newType, this->direction());
+
+  return true;
 }
 
 
@@ -467,7 +465,7 @@ bool FFa3DLocation::isValid() const
 
 std::ostream& operator << (std::ostream& s, const FFa3DLocation& m)
 {
-  if (m.saveMyNumericalData)
+  if (m.saveNumericalData)
   {
     // Output everything, using 8 significant digits
     std::ios_base::fmtflags tmpFlag = s.flags(std::ios::fixed);
@@ -491,7 +489,7 @@ std::ostream& operator << (std::ostream& s, const FFa3DLocation& m)
 std::istream& operator >> (std::istream& s, FFa3DLocation& m)
 {
   // Retain the save flag
-  FFa3DLocation m_tmp(m.saveMyNumericalData);
+  FFa3DLocation m_tmp(m.saveNumericalData);
   s >> m_tmp.myPosTyp;
 
   // Check if the numerical data was stored

--- a/src/FFaLib/FFaAlgebra/FFa3DLocation.H
+++ b/src/FFaLib/FFaAlgebra/FFa3DLocation.H
@@ -57,21 +57,24 @@ private:
     FFaEnumEntryEnd;
   };
 
-  bool saveMyNumericalData; //!< If false, only the type enums are saved
+  bool saveNumericalData; //!< If false, only the type enums are saved
 
   FaVec3      myL[3];
   PosTypeEnum myPosTyp;
   RotTypeEnum myRotTyp;
 
 public:
-  FFa3DLocation(bool saveNumericalData = true);
+  //! \brief Default constructor.
+  explicit FFa3DLocation(bool saveNumData = false);
+  //! \brief Constructor definining the orientation from two direction vectors.
   FFa3DLocation(PosType t, const FaVec3& v0,
 		RotType r, const FaVec3& v1, const FaVec3& v2);
+  //! \brief Constructor definining the orientation from rotation angles.
   FFa3DLocation(PosType t, const FaVec3& v0, RotType r, const FaVec3& v1);
-  FFa3DLocation(const FFa3DLocation& m) { *this = m; saveMyNumericalData = true; }
+  //! \brief Constructor defining the location from a position matrix.
   FFa3DLocation(const FaMat34& m);
-
-  void setSaveNumericalData(bool doSave) { saveMyNumericalData = doSave; }
+  //! \brief Copy constructor.
+  FFa3DLocation(const FFa3DLocation& m) { *this = m; saveNumericalData = true; }
 
   // Local operators
 
@@ -80,7 +83,10 @@ public:
 
   bool operator== (const FFa3DLocation& m) const { return  isCoincident(m); }
   bool operator!= (const FFa3DLocation& m) const { return !isCoincident(m); }
-  bool isCoincident (const FFa3DLocation& m, double tolerance = 1.0e-7) const;
+
+private:
+  bool isCoincident(const FFa3DLocation& m) const;
+public:
 
   // Indexing
 
@@ -93,8 +99,8 @@ public:
 
   // Converting and setting
 
-  FFa3DLocation& changePosType(PosType newType);
-  FFa3DLocation& changeRotType(RotType newType);
+  bool changePosType(PosType newType);
+  bool changeRotType(RotType newType);
 
   FFa3DLocation& changePosRefCS(const FaMat34& newRef, const FaMat34& oldRef);
   FFa3DLocation& changeRotRefCS(const FaMat34& newRef, const FaMat34& oldRef);
@@ -106,22 +112,18 @@ public:
   FFa3DLocation& setPos(PosType p, const FaVec3& cartPos);
   FFa3DLocation& setRot(RotType r, const FaMat33& rotMat);
 
-  FaVec3  translation() const;
-  FaMat33 direction  () const;
-  FaMat34 getMatrix  () const;
-  FaMat34 getMatrix  (const FaMat34& posRelMx, const FaMat34& rotRelMx) const;
-
-  FFa3DLocation& setIdentity() { *this = FFa3DLocation(); return *this; }
+  FaVec3 translation() const;
+  FaMat33 direction() const;
+  FaMat34 getMatrix() const;
+  FaMat34 getMatrix(const FaMat34& posRelMx, const FaMat34& rotRelMx) const;
   bool isValid() const;
 
   // Global operators
 
-  friend std::ostream& operator<< ( std::ostream& s, const FFa3DLocation& m);
-  friend std::istream& operator>> ( std::istream& s, FFa3DLocation& m);
+  friend std::ostream& operator<< (std::ostream& s, const FFa3DLocation& m);
+  friend std::istream& operator>> (std::istream& s, FFa3DLocation& m);
 };
 
-
-// --- inline functions ---
 
 inline const FaVec3& FFa3DLocation::operator[] (int i) const
 {


### PR DESCRIPTION
Remove method `FFa3DLocation::setSaveNumericalData()` and let the default constructor initialize the `saveNumericalData` member to false. Change return type of the `change[Pos|Rot]Type()` methods to bool. Make the `isCoincident() method private (used by operator== and != only).