### PR TITLE
Some FaMat33 and FaMat34 updates

### DIFF
--- a/src/FFaLib/FFaAlgebra/FFa3DLocation.C
+++ b/src/FFaLib/FFaAlgebra/FFa3DLocation.C
@@ -355,7 +355,7 @@ FaMat33 FFa3DLocation::direction() const
       result.eulerRotateZYX(myL[1]*M_PI/180.0);
       break;
     case PNT_PX_PXY:
-      mx.makeCS_X_YX(this->translation(), myL[1], myL[2]);
+      mx.makeCS_X_XY(this->translation(), myL[1], myL[2]);
       result = mx.direction();
       break;
     case PNT_PZ_PXZ:
@@ -363,7 +363,7 @@ FaMat33 FFa3DLocation::direction() const
       result = mx.direction();
       break;
     case DIR_EX_EXY:
-      mx.makeCS_X_YX(FaVec3(), myL[1], myL[2]);
+      mx.makeCS_X_XY(FaVec3(), myL[1], myL[2]);
       result = mx.direction();
       break;
     }

--- a/src/FFaLib/FFaAlgebra/FFaMat33.C
+++ b/src/FFaLib/FFaAlgebra/FFaMat33.C
@@ -525,6 +525,12 @@ FaVec3 operator* (const FaMat33& m, const FaVec3& v1)
 }
 
 
+FaVec3 operator* (const FaVec3& v1, const FaMat33& m)
+{
+  return FaVec3(v1*m.v[0], v1*m.v[1], v1*m.v[2]);
+}
+
+
 FaMat33 operator/ (const FaMat33& a, double d)
 {
   if (fabs(d) < EPS_ZERO)

--- a/src/FFaLib/FFaAlgebra/FFaMat33.H
+++ b/src/FFaLib/FFaAlgebra/FFaMat33.H
@@ -77,6 +77,7 @@ public:
   friend FaMat33  operator*  (const FaMat33& a, double d);
   friend FaMat33  operator*  (double d, const FaMat33& a);
   friend FaVec3   operator*  (const FaMat33& a, const FaVec3&  b);
+  friend FaVec3   operator*  (const FaVec3&  a, const FaMat33& b);
   friend FaMat33  operator/  (const FaMat33& a, double d);
 
   friend int      operator== (const FaMat33& a, const FaMat33& b);

--- a/src/FFaLib/FFaAlgebra/FFaMat34.C
+++ b/src/FFaLib/FFaAlgebra/FFaMat34.C
@@ -77,8 +77,7 @@ FaMat34& FaMat34::operator/= (double d)
 
 FaMat34 FaMat34::inverse() const
 {
-  FaMat33 dirMat = r.transpose();
-  return FaMat34(dirMat,-(dirMat*p));
+  return FaMat34(r.transpose(),-p*r);
 }
 
 
@@ -171,6 +170,11 @@ FaVec3 FaMat34::getEulerZYX() const
   return r.getEulerZYX();
 }
 
+FaVec3 FaMat34::getEulerZYX(const FaMat34& from) const
+{
+  return (from.r.transpose()*r).getEulerZYX();
+}
+
 
 double FaMat34::getEulerZYX(int i) const
 {
@@ -191,28 +195,6 @@ double FaMat34::getRotation(int i) const
 double FaMat34::getRotation(int i, const FaMat34& from) const
 {
   return (from.r.transpose()*r).getRotation()[i];
-}
-
-
-FaVec3 FaMat34::getEulerZYX(const FaMat34& from, const FaMat34& to)
-{
-  return (from.r.transpose()*to.r).getEulerZYX();
-}
-
-
-FaMat34 FaMat34::makeZrotation(double rot)
-{
-  return FaMat34(FaMat33::makeZrotation(rot),FaVec3());
-}
-
-FaMat34 FaMat34::makeYrotation(double rot)
-{
-  return FaMat34(FaMat33::makeYrotation(rot),FaVec3());
-}
-
-FaMat34 FaMat34::makeXrotation(double rot)
-{
-  return FaMat34(FaMat33::makeXrotation(rot),FaVec3());
 }
 
 

--- a/src/FFaLib/FFaAlgebra/FFaMat34.H
+++ b/src/FFaLib/FFaAlgebra/FFaMat34.H
@@ -83,16 +83,13 @@ public:
                        const FaVec3& zpt, const FaVec3& xzpl);
 
   FaVec3 projectOnXY(const FaVec3& x) const;
+
   FaVec3 getEulerZYX() const;
+  FaVec3 getEulerZYX(const FaMat34& from) const;
   double getEulerZYX(int i) const;
   double getEulerZYX(int i, const FaMat34& from) const;
   double getRotation(int i) const;
   double getRotation(int i, const FaMat34& from) const;
-
-  static FaVec3  getEulerZYX  (const FaMat34& from, const FaMat34& to);
-  static FaMat34 makeZrotation(double angle);
-  static FaMat34 makeYrotation(double angle);
-  static FaMat34 makeXrotation(double angle);
 
   // Reading and writing
 
@@ -159,6 +156,4 @@ inline double& FaMat34::operator() (int i, int j)
   return j == 4 ? p[i-1] : r[j-1][i-1];
 }
 
-//TODO: Remove the symbol "makeCS_X_YX", use "makeCS_X_XY" instead
-#define makeCS_X_YX makeCS_X_XY
 #endif

--- a/src/FFaLib/FFaDefinitions/FFaViewItemUtils.C
+++ b/src/FFaLib/FFaDefinitions/FFaViewItemUtils.C
@@ -19,13 +19,13 @@
 
 bool FFaViewItem::compareDescr(FFaViewItem* i1, FFaViewItem* i2)
 {
-  // If any of the pointers are 0, return as if the 0 pointer is first
+  // If any of the pointers are NULL, return as if the NULL-pointer is first
 
   if (!(i1 && i2))
     return !i1;
 
   // Binary compare descriptions
-  // If descriptions are equal, compare by ID, unless both are 0
+  // If descriptions are equal, compare by ID, unless both are zero
 
   std::string s1(i1->getItemDescr());
   std::string s2(i2->getItemDescr());
@@ -48,7 +48,7 @@ bool FFaViewItem::compareDescr(FFaViewItem* i1, FFaViewItem* i2)
 
 bool FFaViewItem::compareID(FFaViewItem* i1, FFaViewItem* i2)
 {
-  // If any of the pointers are 0, return as if the 0 pointer is first
+  // If any of the pointers are NULL, return as if the NULL-pointer is first
 
   if (!(i1 && i2))
     return !i1;
@@ -56,7 +56,7 @@ bool FFaViewItem::compareID(FFaViewItem* i1, FFaViewItem* i2)
   int n1 = i1->getItemID();
   int n2 = i2->getItemID();
 
-  // Put items with a 0-id at the bottom of the list
+  // Put items with a zero id at the end of the list
   if (n1 == 0) n1 = 2147483647; // maxint
   if (n2 == 0) n2 = 2147483647; // maxint
 
@@ -73,13 +73,13 @@ bool FFaViewItem::compareID(FFaViewItem* i1, FFaViewItem* i2)
 
 int FFaViewItem::compareDescr3w(FFaViewItem* i1, FFaViewItem* i2)
 {
-  // If any of the pointers are 0, return as if the 0 pointer is first
+  // If any of the pointers are NULL, return as if the NULL-pointer is first
 
   if (!(i1 && i2))
   {
     if (i1 == i2)
       return 0;
-    else if (i1 == 0)
+    else if (!i1)
       return -1;
     else
       return 1;
@@ -95,13 +95,13 @@ int FFaViewItem::compareDescr3w(FFaViewItem* i1, FFaViewItem* i2)
 
 int FFaViewItem::compareID3w(FFaViewItem* i1, FFaViewItem* i2)
 {
-  // If any of the pointers are 0, return as if the 0 pointer is first
+  // If any of the pointers are NULL, return as if the NULL-pointer is first
 
   if (!(i1 && i2))
   {
     if (i1 == i2)
       return 0;
-    else if (i1 == 0)
+    else if (!i1)
       return -1;
     else
       return 1;
@@ -126,7 +126,7 @@ int FFaViewItem::compareID3w(FFaViewItem* i1, FFaViewItem* i2)
 static int stringCompare3wImpl(const std::string& s1, const std::string& s2)
 {
   // Lambda function doing case-insensitive 3-way comparison of two characters.
-  std::function<int(char,char)> charCompare3w = [](char c1, char c2) -> int
+  std::function<int(char,char)> charCompare = [](char c1, char c2) -> int
   {
     int lc1 = tolower(static_cast<unsigned char>(c1));
     int lc2 = tolower(static_cast<unsigned char>(c2));
@@ -134,11 +134,11 @@ static int stringCompare3wImpl(const std::string& s1, const std::string& s2)
   };
 
   std::pair<std::string::const_iterator,std::string::const_iterator> p;
-  p = std::mismatch(s1.begin(), s1.end(), s2.begin(), std::not2(charCompare3w));
+  p = std::mismatch(s1.begin(), s1.end(), s2.begin(), std::not_fn(charCompare));
   if (p.first == s1.end())
     return p.second == s2.end() ? 0 : -1;
 
-  return charCompare3w(*p.first,*p.second);
+  return charCompare(*p.first,*p.second);
 }
 
 

--- a/src/FFaLib/FFaTests/test_FFa.C
+++ b/src/FFaLib/FFaTests/test_FFa.C
@@ -15,10 +15,11 @@
 #include "gtest.h"
 #include "FFaLib/FFaOS/FFaFilePath.H"
 #include "FFaLib/FFaAlgebra/FFaMath.H"
-#include "FFaLib/FFaAlgebra/FFaVec3.H"
+#include "FFaLib/FFaAlgebra/FFaMat34.H"
 #include "FFaLib/FFaAlgebra/FFaCheckSum.H"
 #include "FFaLib/FFaString/FFaStringExt.H"
 #include <array>
+#include <numeric>
 
 int BodyTest (const std::string& fname, double z0, double z1);
 
@@ -52,7 +53,8 @@ int main (int argc, char** argv)
 
 
 //! \brief Class describing a parameterized unit test instance for FFaBody.
-class TestFFaBody : public testing::Test, public testing::WithParamInterface<const char*> {};
+class TestFFaBody : public testing::Test,
+                    public testing::WithParamInterface<const char*> {};
 
 
 /*!
@@ -128,10 +130,11 @@ TEST(TestFFa,FilePath)
 
 
 //! \brief Data type to instantiate particular unit tests over.
-typedef std::array<double,5> Case;
+using Case = std::array<double,5>;
 
 //! \brief Class describing a parameterized unit test instance for cubicSolve().
-class TestFFaCubic : public testing::Test, public testing::WithParamInterface<Case> {};
+class TestFFaCubic : public testing::Test,
+                     public testing::WithParamInterface<Case> {};
 
 
 /*!
@@ -153,7 +156,7 @@ TEST_P(TestFFaCubic, Solve)
   if (B != 0.0) std::cout << B <<"*x^2 + ";
   if (C != 0.0) std::cout << C <<"*x - ";
   double sol[3];
-  std::cout << D <<" = 0"<< std::endl;
+  std::cout << D <<" = 0\n";
   int nSol = FFa::cubicSolve(A,B,C,-D,sol);
   ASSERT_GT(nSol,0);
   bool found = false;
@@ -184,10 +187,11 @@ INSTANTIATE_TEST_CASE_P(TestSolve, TestFFaCubic,
 
 
 //! \brief Data type to instantiate particular unit tests over.
-typedef std::array<double,8> CaseII;
+using CaseII = std::array<double,8>;
 
 //! \brief Class describing a parameterized unit test instance for bilinearSolve().
-class TestFFaBilin : public testing::Test, public testing::WithParamInterface<CaseII> {};
+class TestFFaBilin : public testing::Test,
+                     public testing::WithParamInterface<CaseII> {};
 
 
 /*!
@@ -292,4 +296,47 @@ TEST(TestFFa,String)
   std::cout <<"FixDof: \""<< FixDof <<"\""<< std::endl;
   EXPECT_FALSE(FFaString("jalla #FixX").hasSubString(FixDof));
   EXPECT_TRUE(FFaString("peder #FixY").hasSubString(FixDof));
+}
+
+
+/*!
+  Creates some Mat33 unit tests.
+*/
+
+TEST(TestFFa,Mat33)
+{
+  double values[9];
+  std::iota(values,values+9,1.0);
+  FaMat33 A(values);
+  FaVec3 b(0.1,0.2,0.3);
+  FaVec3 c = A.transpose()*b;
+  FaVec3 d = b*A;
+  std::cout <<"\nA = "<< A;
+  std::cout <<"\nb = "<< b;
+  std::cout <<"\nA^t*b = "<< c;
+  std::cout <<"\nb * A = "<< d;
+  std::cout << std::endl;
+
+  EXPECT_EQ(c.x(),d.x());
+  EXPECT_EQ(c.y(),d.y());
+  EXPECT_EQ(c.z(),d.z());
+}
+
+
+/*!
+  Creates some Mat34 unit tests.
+*/
+
+TEST(TestFFa,Mat34)
+{
+  FaMat34 A;
+  A.makeCS_X_XY(FaVec3(1.2,3.4,5.6),FaVec3(7.8,9.0,1.2),FaVec3(3.4,5.6,7.8));
+  FaMat34 B = A.inverse()*A;
+
+  std::cout <<"\nA = "<< A;
+  std::cout <<"\nA^-1 = "<< A.inverse();
+  std::cout <<"\nB = "<< B;
+  std::cout << std::endl;
+
+  EXPECT_TRUE(B.isCoincident(FaMat34(),1.0e-16));
 }


### PR DESCRIPTION
Mainly, adding a `FaVec3*FaMat33` operator such that one can to `v*A` instead of the equivalent `A.transpose()*v`. Then some cleaning of unused static methods in FaMat34 and changing the static getEulerZYX() into a single-argument non-static method operating on *this. Through the sub-module update, we now enforce the C++17 standard, making `std::not2()` deprecated and therefore replaced.