### PR TITLE
Don't enforce 6 DOFs for WAVGM reference nodes when no rotations

### DIFF
--- a/src/FFaLib/FFaAlgebra/FFaTensor1.C
+++ b/src/FFaLib/FFaAlgebra/FFaTensor1.C
@@ -8,7 +8,6 @@
 #include "FFaLib/FFaAlgebra/FFaTensor1.H"
 #include "FFaLib/FFaAlgebra/FFaTensor2.H"
 #include "FFaLib/FFaAlgebra/FFaTensor3.H"
-#include <cctype>
 #include <cmath>
 
 

--- a/src/FFaLib/FFaAlgebra/FFaTensor1.H
+++ b/src/FFaLib/FFaAlgebra/FFaTensor1.H
@@ -33,6 +33,8 @@ public:
   FFaTensor1(const FFaTensor2& t);
   FFaTensor1(const FFaTensor3& t);
 
+  void fill(double d) { myT = d; }
+
   // Local operators
 
   FFaTensor1& operator= (const FFaTensor1& t);

--- a/src/FFaLib/FFaAlgebra/FFaTensor2.C
+++ b/src/FFaLib/FFaAlgebra/FFaTensor2.C
@@ -11,7 +11,6 @@
 #include "FFaLib/FFaAlgebra/FFaMat33.H"
 #include "FFaLib/FFaAlgebra/FFaMat34.H"
 #include "FFaLib/FFaAlgebra/FFaTensorTransforms.H"
-#include <cctype>
 
 
 FFaTensor2::FFaTensor2(const FFaTensor3& t)
@@ -64,7 +63,7 @@ FFaTensor2& FFaTensor2::operator= (const FFaTensor1& t)
 
 FFaTensor2& FFaTensor2::rotate(const double ex[2], const double ey[2])
 {
-  FFaTensorTransforms::rotate(myT,ex,ey, myT);
+  FFaTensorTransforms::rotate(myT.data(), ex,ey, myT.data());
   return *this;
 }
 
@@ -102,7 +101,7 @@ double FFaTensor2::maxShear() const
 void FFaTensor2::maxShear(FaVec3& v) const
 {
   double values[2], max[2], min[2];
-  if (FFaTensorTransforms::principalDirs(myT,values,max,min) == 0)
+  if (FFaTensorTransforms::principalDirs(myT.data(),values,max,min) == 0)
   {
     v[2] = 0.0;
     FFaTensorTransforms::maxShearDir(2,max,min,v.getPt());
@@ -166,7 +165,7 @@ void FFaTensor2::prinsipalValues(FaVec3& values, FaMat33& rotation) const
 {
   values[2] = 0.0;
   rotation.setIdentity();
-  if (FFaTensorTransforms::principalDirs(myT,
+  if (FFaTensorTransforms::principalDirs(myT.data(),
                                          values.getPt(),
                                          rotation[0].getPt(),
                                          rotation[1].getPt()))
@@ -245,7 +244,7 @@ FFaTensor3 operator* (const FFaTensor2& a, const FaMat33 & m)
   FFaTensor3 result;
   FFaTensor3 in(a);
   FFaTensorTransforms::rotate(in.getPt(),
-			      m[0].getPt(), m[1].getPt(), m[2].getPt(),
+                              m[0].getPt(), m[1].getPt(), m[2].getPt(),
                               result.getPt());
   return result;
 }
@@ -255,7 +254,7 @@ FFaTensor3 operator* (const FFaTensor2& a, const FaMat34& m)
   FFaTensor3 result;
   FFaTensor3 in(a);
   FFaTensorTransforms::rotate(in.getPt(),
-			      m[0].getPt(), m[1].getPt(), m[2].getPt(),
+                              m[0].getPt(), m[1].getPt(), m[2].getPt(),
                               result.getPt());
   return result;
 }

--- a/src/FFaLib/FFaAlgebra/FFaTensor2.H
+++ b/src/FFaLib/FFaAlgebra/FFaTensor2.H
@@ -8,6 +8,7 @@
 #ifndef FFA_TENSOR2_H
 #define FFA_TENSOR2_H
 
+#include <array>
 #include <iostream>
 
 class FaVec3;
@@ -25,21 +26,21 @@ class FFaTensor3;
 
 class FFaTensor2
 {
-  double myT[3];
+  std::array<double,3> myT;
 
 public:
 
   // Constructors
 
-  FFaTensor2()                    { myT[0] = myT[1] = myT[2] = 0.0; }
-  FFaTensor2(double d)            { myT[0] = myT[1] = myT[2] = d; }
+  FFaTensor2(double d = 0.0)      { myT.fill(d); }
   FFaTensor2(const float* t)      { for (int i=0; i<3; i++) myT[i] = t[i]; }
   FFaTensor2(const double* t)     { for (int i=0; i<3; i++) myT[i] = t[i]; }
   FFaTensor2(const FFaTensor2& t) { for (int i=0; i<3; i++) myT[i] = t.myT[i]; }
   FFaTensor2(const FFaTensor1& t);
   FFaTensor2(const FFaTensor3& t);
-  FFaTensor2(double t11, double t22, double t12 = 0.0)
-  { myT[0] = t11; myT[1] = t22; myT[2] = t12; }
+  FFaTensor2(double t11, double t22, double t12 = 0.0) { myT = {t11,t22,t12}; }
+
+  void fill(double d) { myT.fill(d); }
 
   // Local operators
 
@@ -73,8 +74,8 @@ public:
 
   // Access to internal array
 
-  const double* getPt() const { return myT; }
-  double*       getPt()       { return myT; }
+  const double* getPt() const { return myT.data(); }
+  double*       getPt()       { return myT.data(); }
 
   // Indexing
 
@@ -122,8 +123,8 @@ inline const double& FFaTensor2::operator[] (int i) const
 {
 #ifdef FFA_INDEXCHECK
   if (i < 0 || i > 2)
-    std::cerr <<"FFaTensor2::operator[]: index i="<< i <<" is out of range [0,2]"
-	      << std::endl;
+    std::cerr <<"FFaTensor2::operator[]: index i="<< i
+              <<" is out of range [0,2]"<< std::endl;
 #endif
   return myT[i];
 }
@@ -132,8 +133,8 @@ inline double& FFaTensor2::operator[] (int i)
 {
 #ifdef FFA_INDEXCHECK
   if (i < 0 || i > 2)
-    std::cerr <<"FFaTensor2::operator[]: index i="<< i <<" is out of range [0,2]"
-	      << std::endl;
+    std::cerr <<"FFaTensor2::operator[]: index i="<< i
+              <<" is out of range [0,2]"<< std::endl;
 #endif
   return myT[i];
 }

--- a/src/FFaLib/FFaAlgebra/FFaTensor3.C
+++ b/src/FFaLib/FFaAlgebra/FFaTensor3.C
@@ -11,7 +11,6 @@
 #include "FFaLib/FFaAlgebra/FFaMat33.H"
 #include "FFaLib/FFaAlgebra/FFaMat34.H"
 #include "FFaLib/FFaAlgebra/FFaTensorTransforms.H"
-#include <cctype>
 
 
 FFaTensor3::FFaTensor3(const FFaTensor2& t)
@@ -71,22 +70,22 @@ FFaTensor3& FFaTensor3::operator= (const FFaTensor1& t)
 
 FFaTensor3& FFaTensor3::rotate(const FaMat33& rotMx)
 {
-  FFaTensorTransforms::rotate(myT,
+  FFaTensorTransforms::rotate(myT.data(),
                               rotMx[0].getPt(),
                               rotMx[1].getPt(),
                               rotMx[2].getPt(),
-                              myT);
+                              myT.data());
   return *this;
 }
 
 
 FFaTensor3& FFaTensor3::rotate(const FaMat34& rotMx)
 {
-  FFaTensorTransforms::rotate(myT,
+  FFaTensorTransforms::rotate(myT.data(),
                               rotMx[0].getPt(),
                               rotMx[1].getPt(),
                               rotMx[2].getPt(),
-                              myT);
+                              myT.data());
   return *this;
 }
 
@@ -174,7 +173,7 @@ double FFaTensor3::maxShear() const
 void FFaTensor3::maxShear(FaVec3& v) const
 {
   double values[3], max[3], middle[3], min[3];
-  if (FFaTensorTransforms::principalDirs(myT,values,max,middle,min) == 0)
+  if (FFaTensorTransforms::principalDirs(myT.data(),values,max,middle,min) == 0)
   {
     FFaTensorTransforms::maxShearDir(3,max,min,v.getPt());
     v *= FFaTensorTransforms::maxShearValue(values[0],values[2]);
@@ -258,7 +257,7 @@ void FFaTensor3::prinsipalValues(double& max, double& middle, double& min) const
 
 void FFaTensor3::prinsipalValues(FaVec3& values, FaMat33& rotation) const
 {
-  if (FFaTensorTransforms::principalDirs(myT,
+  if (FFaTensorTransforms::principalDirs(myT.data(),
                                          values.getPt(),
                                          rotation[0].getPt(),
                                          rotation[1].getPt(),
@@ -355,16 +354,18 @@ bool operator!= (const FFaTensor3& a, const FFaTensor3& b)
 FFaTensor3 operator* (const FFaTensor3& a, const FaMat33& m)
 {
   FFaTensor3 result;
-  FFaTensorTransforms::rotate(a.myT, m[0].getPt(), m[1].getPt(), m[2].getPt(),
-                              result.myT);
+  FFaTensorTransforms::rotate(a.myT.data(),
+                              m[0].getPt(), m[1].getPt(), m[2].getPt(),
+                              result.myT.data());
   return result;
 }
 
 FFaTensor3 operator* (const FFaTensor3& a, const FaMat34& m)
 {
   FFaTensor3 result;
-  FFaTensorTransforms::rotate(a.myT, m[0].getPt(), m[1].getPt(), m[2].getPt(),
-                              result.myT);
+  FFaTensorTransforms::rotate(a.myT.data(),
+                              m[0].getPt(), m[1].getPt(), m[2].getPt(),
+                              result.myT.data());
   return result;
 }
 

--- a/src/FFaLib/FFaAlgebra/FFaTensor3.H
+++ b/src/FFaLib/FFaAlgebra/FFaTensor3.H
@@ -8,6 +8,7 @@
 #ifndef FFA_TENSOR3_H
 #define FFA_TENSOR3_H
 
+#include <array>
 #include <iostream>
 
 class FaVec3;
@@ -25,14 +26,13 @@ class FFaTensor2;
 
 class FFaTensor3
 {
-  double myT[6];
+  std::array<double,6> myT;
 
 public:
 
   // Constructors
 
-  FFaTensor3()                    { for (int i=0; i<6; i++) myT[i] = 0.0; }
-  FFaTensor3(double d)            { for (int i=0; i<6; i++) myT[i] = d; }
+  FFaTensor3(double d = 0.0)      { myT.fill(d); }
   FFaTensor3(const float* t)      { for (int i=0; i<6; i++) myT[i] = t[i]; }
   FFaTensor3(const double* t)     { for (int i=0; i<6; i++) myT[i] = t[i]; }
   FFaTensor3(const FFaTensor3& t) { for (int i=0; i<6; i++) myT[i] = t.myT[i]; }
@@ -42,13 +42,14 @@ public:
   FFaTensor3(double t11      , double t22      , double t33,
              double t12 = 0.0, double t13 = 0.0, double t23 = 0.0)
   {
-    myT[0] = t11; myT[1] = t22; myT[2] = t33;
-    myT[3] = t12; myT[4] = t13; myT[5] = t23;
+    myT = { t11, t22, t33, t12, t13, t23 };
   }
   FFaTensor3(const FaVec3& v1, const FaVec3& v2, const FaVec3& v3)
   {
     this->makeInertia(v1,v2,v3);
   }
+
+  void fill(double d) { myT.fill(d); }
 
   // Local operators
 
@@ -82,8 +83,8 @@ public:
 
   // Access to internal array
 
-  const double* getPt() const { return myT; }
-  double*       getPt()       { return myT; }
+  const double* getPt() const { return myT.data(); }
+  double*       getPt()       { return myT.data(); }
 
   // Indexing
 
@@ -136,8 +137,8 @@ inline const double& FFaTensor3::operator[] (int i) const
 {
 #ifdef FFA_INDEXCHECK
   if (i < 0 || i > 5)
-    std::cerr <<"FFaTensor3::operator[]: index i="<< i <<" is out of range [0,5]"
-	      << std::endl;
+    std::cerr <<"FFaTensor3::operator[]: index i="<< i
+              <<" is out of range [0,5]"<< std::endl;
 #endif
   return myT[i];
 }
@@ -146,8 +147,8 @@ inline double& FFaTensor3::operator[] (int i)
 {
 #ifdef FFA_INDEXCHECK
   if (i < 0 || i > 5)
-    std::cerr <<"FFaTensor3::operator[]: index i="<< i <<" is out of range [0,5]"
-	      << std::endl;
+    std::cerr <<"FFaTensor3::operator[]: index i="<< i
+              <<" is out of range [0,5]"<< std::endl;
 #endif
   return myT[i];
 }

--- a/src/FFlLib/FFlElementBase.C
+++ b/src/FFlLib/FFlElementBase.C
@@ -61,8 +61,14 @@ void FFlElementBase::calculateChecksum(FFaCheckSum* cs, int) const
   FFlVisualRefs::checksum(cs,cstype);
 #elif defined(FFL_DEBUG)
   if ((cstype & FFl::CS_VISUALMASK) != FFl::CS_NOVISUALINFO)
-    std::cout <<"FFlElementBase::calculateChecksum: Visuals ignored"
-              << std::endl;
+  {
+    static int ignored = 0;
+    if (++ignored <= 10)
+      std::cout <<"FFlElementBase::calculateChecksum: Visuals ignored"
+                << std::endl;
+    else if (ignored == 11)
+      std::cout <<"..."<< std::endl;
+  }
 #endif
 }
 
@@ -81,20 +87,21 @@ double FFlElementBase::getMassDensity() const
 }
 
 
-bool FFlElementBase::getVolumeAndInertia(double& volume, FaVec3& cog,
-					 FFaTensor3& inertia) const
+double FFlElementBase::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inert) const
 {
-  volume  = 0.0;
-  cog     = FaVec3(0.0,0.0,0.0);
-  inertia = FFaTensor3(0.0);
-  return false;
+  cog.clear();
+  if (inert)
+    inert->fill(0.0);
+
+  return 0.0;
 }
 
 
 bool FFlElementBase::getMassProperties(double& mass, FaVec3& cog,
 				       FFaTensor3& inertia) const
 {
-  if (!this->getVolumeAndInertia(mass,cog,inertia)) return false;
+  if ((mass = this->getVolumeAndCoG(cog,&inertia)) <= 0.0)
+    return false;
 
   double rho = this->getMassDensity();
   mass    *= rho;

--- a/src/FFlLib/FFlElementBase.H
+++ b/src/FFlLib/FFlElementBase.H
@@ -73,8 +73,7 @@ public:
 
   // Structural properties:
   virtual double getMassDensity() const;
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-				   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inert = NULL) const;
   bool getMassProperties(double& mass, FaVec3& cog, FFaTensor3& inertia) const;
 
   // Geometrical mapping:

--- a/src/FFlLib/FFlFEParts/FFlBeams.C
+++ b/src/FFlLib/FFlFEParts/FFlBeams.C
@@ -71,11 +71,10 @@ double FFlBEAM2::getMassDensity() const
 }
 
 
-bool FFlBEAM2::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlBEAM2::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FFlPBEAMSECTION* psec = dynamic_cast<FFlPBEAMSECTION*>(this->getAttribute("PBEAMSECTION"));
-  if (!psec) return false; // Should not happen
+  if (!psec) return -1.0; // Should not happen
 
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
@@ -90,8 +89,9 @@ bool FFlBEAM2::getVolumeAndInertia(double& volume, FaVec3& cog,
 
   double A = psec->crossSectionArea.getValue();
   double L = (v2-v1).length();
+  double V = A*L;
   cog      = (v1+v2)*0.5;
-  volume   = A*L;
+  if (!inertia) return V;
 
   // Compute local coordinate system
   FaMat33 Telm;
@@ -109,14 +109,15 @@ bool FFlBEAM2::getVolumeAndInertia(double& volume, FaVec3& cog,
 
   // Set up the inertia tensor in local axes
   double Ixx = psec->Iy.getValue() + psec->Iz.getValue();
-  inertia[0] = L*(Ixx > 0.0 ? Ixx : psec->It.getValue());
-  inertia[1] = L*(psec->Iy.getValue() + A*L*L/12.0);
-  inertia[2] = L*(psec->Iz.getValue() + A*L*L/12.0);
-  inertia[3] = inertia[4] = inertia[5] = 0.0;
+  FFaTensor3& I = *inertia;
+  I[0] = L*(Ixx > 0.0 ? Ixx : psec->It.getValue());
+  I[1] = L*(psec->Iy.getValue() + A*L*L/12.0);
+  I[2] = L*(psec->Iz.getValue() + A*L*L/12.0);
+  I[3] = I[4] = I[5] = 0.0;
 
   // Transform to global axes
-  inertia.rotate(Telm.transpose());
-  return true;
+  inertia->rotate(Telm.transpose());
+  return V;
 }
 
 
@@ -312,11 +313,10 @@ double FFlBEAM3::getMassDensity() const
 }
 
 
-bool FFlBEAM3::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlBEAM3::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FFlPBEAMSECTION* psec = dynamic_cast<FFlPBEAMSECTION*>(this->getAttribute("PBEAMSECTION"));
-  if (!psec) return false; // Should not happen
+  if (!psec) return -1.0; // Should not happen
 
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
@@ -333,8 +333,9 @@ bool FFlBEAM3::getVolumeAndInertia(double& volume, FaVec3& cog,
 
   double A = psec->crossSectionArea.getValue();
   double L = (v2-v1).length() + (v3-v2).length();
+  double V = A*L;
   cog      = (v1+v3)*0.25 + v2*0.5;
-  volume   = A*L;
+  if (!inertia) return V;
 
   // Compute local coordinate system
   FFlPORIENT* pori = dynamic_cast<FFlPORIENT*>(this->getAttribute("PORIENT"));
@@ -355,14 +356,15 @@ bool FFlBEAM3::getVolumeAndInertia(double& volume, FaVec3& cog,
 
   // Set up the inertia tensor in local axes
   double Ixx = psec->Iy.getValue() + psec->Iz.getValue();
-  inertia[0] = L*(Ixx > 0.0 ? Ixx : psec->It.getValue());
-  inertia[1] = L*(psec->Iy.getValue() + A*L*L/12.0);
-  inertia[2] = L*(psec->Iz.getValue() + A*L*L/12.0);
-  inertia[3] = inertia[4] = inertia[5] = 0.0;
+  FFaTensor3& I = *inertia;
+  I[0] = L*(Ixx > 0.0 ? Ixx : psec->It.getValue());
+  I[1] = L*(psec->Iy.getValue() + A*L*L/12.0);
+  I[2] = L*(psec->Iz.getValue() + A*L*L/12.0);
+  I[3] = I[4] = I[5] = 0.0;
 
   // Transform to global axes
-  inertia.rotate(Telm.transpose());
-  return true;
+  inertia->rotate(Telm.transpose());
+  return V;
 }
 
 #ifdef FF_NAMESPACE

--- a/src/FFlLib/FFlFEParts/FFlBeams.H
+++ b/src/FFlLib/FFlFEParts/FFlBeams.H
@@ -25,7 +25,6 @@ class FFlBEAM2 : public FFlElementBase
 {
 public:
   FFlBEAM2(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlBEAM2() {}
 
   static void init();
 
@@ -35,8 +34,7 @@ public:
   FFL_TYPE_INFO(FFlBEAM2);
 
   virtual double getMassDensity() const;
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
   virtual int getNodalCoor(double* X, double* Y, double* Z) const;
   FaVec3 getLocalZdirection() const;
 
@@ -50,7 +48,6 @@ class FFlBEAM3 : public FFlElementBase
 {
 public:
   FFlBEAM3(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlBEAM3() {}
 
   static void init();
 
@@ -60,8 +57,7 @@ public:
   FFL_TYPE_INFO(FFlBEAM3);
 
   virtual double getMassDensity() const;
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
   //! \brief Splits the 3-noded beam element into two 2-noded elements.
   virtual bool split(Elements& newElm, FFlLinkHandler* owner, int);

--- a/src/FFlLib/FFlFEParts/FFlCMASS.C
+++ b/src/FFlLib/FFlFEParts/FFlCMASS.C
@@ -37,27 +37,26 @@ void FFlCMASS::init()
 }
 
 
-bool FFlCMASS::getVolumeAndInertia(double& volume, FaVec3& cog,
-				   FFaTensor3& inertia) const
+double FFlCMASS::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
-  volume = 0.0;
   cog = this->getNode(1)->getPos();
 
   FFlPMASS* pmass = dynamic_cast<FFlPMASS*>(this->getAttribute("PMASS"));
   if (!pmass)
   {
     // Property-less mass element, ignore
-    inertia = FFaTensor3(0.0);
-    return true;
+    if (inertia)
+      inertia->fill(0.0);
+    return 0.0;
   }
 
   const std::vector<double>& M = pmass->M.getValue();
   if (M.size() > 0 && M.size() <= 6)
   {
     // No inertia for this element, only mass
-    volume = M[0];
-    inertia = FFaTensor3(0.0);
-    return true;
+    if (inertia)
+      inertia->fill(0.0);
+    return M[0];
   }
   else if (M.size() != 21)
   {
@@ -82,21 +81,23 @@ bool FFlCMASS::getVolumeAndInertia(double& volume, FaVec3& cog,
   bool haveInertia = RtMR(M,R,II);
 
   // Compute the mass = volume
-  volume = (II[0][0]+II[1][1]+II[2][2]) / 3.0;
+  double V = (II[0][0]+II[1][1]+II[2][2]) / 3.0;
   if (!haveInertia)
   {
-    inertia = FFaTensor3(0.0);
-    return true;
+    if (inertia)
+      inertia->fill(0.0);
+    return V;
   }
-  else if (volume < 1.0e-16)
+  else if (V < 1.0e-16)
   {
     ListUI <<"\n  ** Warning: CMASS element "<< this->getID()
            <<" has zero mass, but non-zero inertia. This is non-physical.\n";
-    return false;
+    return -2.0;
   }
 
   // Adjust the center of gravity for possible offset
-  cog = FaVec3(II[1][5],II[2][3],II[0][4]) / volume;
+  cog = FaVec3(II[1][5],II[2][3],II[0][4]) / V;
+  if (!inertia) return V;
 
   // Compute the inertia tensor about the center of gravity
   R[1][3] += cog[2];
@@ -107,9 +108,9 @@ bool FFlCMASS::getVolumeAndInertia(double& volume, FaVec3& cog,
   R[1][5] -= cog[0];
   RtMR(M,R,II);
 
-  inertia = FFaTensor3(II[3][3],II[4][4],II[5][5],
-                       II[3][4],II[3][5],II[4][5]);
-  return true;
+  *inertia = FFaTensor3(II[3][3],II[4][4],II[5][5],
+                        II[3][4],II[3][5],II[4][5]);
+  return V;
 }
 
 

--- a/src/FFlLib/FFlFEParts/FFlCMASS.H
+++ b/src/FFlLib/FFlFEParts/FFlCMASS.H
@@ -25,7 +25,6 @@ class FFlCMASS : public FFlElementBase
 {
 public:
   FFlCMASS(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlCMASS() {}
 
   static void init();
 
@@ -35,8 +34,7 @@ public:
   FFL_TYPE_INFO(FFlCMASS);
 
   virtual double getMassDensity() const { return 1.0; }
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-				   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 private:
   static bool RtMR(const std::vector<double>& M, double R[6][6], double II[6][6]);

--- a/src/FFlLib/FFlFEParts/FFlShells.C
+++ b/src/FFlLib/FFlFEParts/FFlShells.C
@@ -109,35 +109,37 @@ bool FFlTRI3::getFaceNormals(std::vector<FaVec3>& normals, short int,
 }
 
 
-bool FFlTRI3::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                  FFaTensor3& inertia) const
+double FFlTRI3::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   double th = this->getThickness();
-  if (th <= 0.0) return false; // Should not happen
+  if (th <= 0.0) return -1.0; // Should not happen
 
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
   FaVec3 v3(this->getNode(3)->getPos());
+  cog = (v1 + v2 + v3) / 3.0;
 
   FaVec3 normal = (v2-v1) ^ (v3-v1);
   double length = normal.length();
-  volume = 0.5 * length * th;
-  cog = (v1 + v2 + v3) / 3.0;
-  if (length < 1.0e-16) return false;
+  if (length < 1.0e-16) return -2.0;
 
   // Compute inertias by expanding the shell into a solid
 
-  normal *= th/length;
-  v1 -= cog + 0.5*normal;
-  v2 -= cog + 0.5*normal;
-  v3 -= cog + 0.5*normal;
+  if (inertia)
+  {
+    normal *= th/length;
+    v1 -= cog + 0.5*normal;
+    v2 -= cog + 0.5*normal;
+    v3 -= cog + 0.5*normal;
 
-  FaVec3 v4(v1+normal);
-  FaVec3 v5(v2+normal);
-  FaVec3 v6(v3+normal);
+    FaVec3 v4(v1+normal);
+    FaVec3 v5(v2+normal);
+    FaVec3 v6(v3+normal);
 
-  FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,inertia);
-  return true;
+    FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,*inertia);
+  }
+
+  return 0.5 * length * th; // volume
 }
 
 
@@ -295,11 +297,10 @@ bool FFlTRI6::getFaceNormals(std::vector<FaVec3>& normals, short int,
 }
 
 
-bool FFlTRI6::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                  FFaTensor3& inertia) const
+double FFlTRI6::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   double th = this->getThickness();
-  if (th <= 0.0) return false; // Should not happen
+  if (th <= 0.0) return -1.0; // Should not happen
 
   //TODO,kmo: Account for curved edges and face (by numerical integration)
   FaVec3 v1(this->getNode(1)->getPos());
@@ -308,23 +309,25 @@ bool FFlTRI6::getVolumeAndInertia(double& volume, FaVec3& cog,
 
   FaVec3 normal = (v2-v1) ^ (v3-v1);
   double length = normal.length();
-  volume = 0.5 * length * th;
   cog = (v1 + v2 + v3) / 3.0;
-  if (length < 1.0e-16) return false;
+  if (length < 1.0e-16) return -2.0;
 
   // Compute inertias by expanding the shell into a solid
 
-  normal *= th/length;
-  v1 -= cog + 0.5*normal;
-  v2 -= cog + 0.5*normal;
-  v3 -= cog + 0.5*normal;
+  if (inertia)
+  {
+    normal *= th/length;
+    v1 -= cog + 0.5*normal;
+    v2 -= cog + 0.5*normal;
+    v3 -= cog + 0.5*normal;
 
-  FaVec3 v4(v1+normal);
-  FaVec3 v5(v2+normal);
-  FaVec3 v6(v3+normal);
+    FaVec3 v4(v1+normal);
+    FaVec3 v5(v2+normal);
+    FaVec3 v6(v3+normal);
 
-  FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,inertia);
-  return true;
+    FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,*inertia);
+  }
+  return 0.5 * length * th; // volume
 }
 
 
@@ -401,11 +404,10 @@ bool FFlQUAD4::getFaceNormals(std::vector<FaVec3>& normals, short int,
 }
 
 
-bool FFlQUAD4::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlQUAD4::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   double th = this->getThickness();
-  if (th <= 0.0) return false; // Should not happen
+  if (th <= 0.0) return -1.0; // Should not happen
 
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
@@ -415,28 +417,31 @@ bool FFlQUAD4::getVolumeAndInertia(double& volume, FaVec3& cog,
   double a1 = ((v2-v1) ^ (v3-v1)).length();
   double a2 = ((v3-v1) ^ (v4-v1)).length();
 
-  volume = 0.5*(a1+a2)*th;
   cog = ((v1+v3)*(a1+a2) + v2*a1 + v4*a2) / ((a1+a2)*3.0);
 
   // Compute inertias by expanding the shell into a solid
 
-  FaVec3 normal = (v3-v1) ^ (v4-v2);
-  double length = normal.length();
-  if (length < 1.0e-16) return false;
+  if (inertia)
+  {
+    FaVec3 normal = (v3-v1) ^ (v4-v2);
+    double length = normal.length();
+    if (length < 1.0e-16) return -2.0;
 
-  normal *= th/length;
-  v1 -= cog + 0.5*normal;
-  v2 -= cog + 0.5*normal;
-  v3 -= cog + 0.5*normal;
-  v4 -= cog + 0.5*normal;
+    normal *= th/length;
+    v1 -= cog + 0.5*normal;
+    v2 -= cog + 0.5*normal;
+    v3 -= cog + 0.5*normal;
+    v4 -= cog + 0.5*normal;
 
-  FaVec3 v5(v1+normal);
-  FaVec3 v6(v2+normal);
-  FaVec3 v7(v3+normal);
-  FaVec3 v8(v4+normal);
+    FaVec3 v5(v1+normal);
+    FaVec3 v6(v2+normal);
+    FaVec3 v7(v3+normal);
+    FaVec3 v8(v4+normal);
 
-  FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,inertia);
-  return true;
+    FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,*inertia);
+  }
+
+  return 0.5*(a1+a2)*th; // volume
 }
 
 
@@ -663,11 +668,10 @@ bool FFlQUAD8::getFaceNormals(std::vector<FaVec3>& normals, short int,
 }
 
 
-bool FFlQUAD8::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlQUAD8::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   double th = this->getThickness();
-  if (th <= 0.0) return false; // Should not happen
+  if (th <= 0.0) return -1.0; // Should not happen
 
   //TODO,kmo: Account for curved edges and face (by numerical integration)
   FaVec3 v1(this->getNode(1)->getPos());
@@ -678,28 +682,31 @@ bool FFlQUAD8::getVolumeAndInertia(double& volume, FaVec3& cog,
   double a1 = ((v2-v1) ^ (v3-v1)).length();
   double a2 = ((v3-v1) ^ (v4-v1)).length();
 
-  volume = 0.5*(a1+a2)*th;
   cog = ((v1+v3)*(a1+a2) + v2*a1 + v4*a2) / ((a1+a2)*3.0);
 
   // Compute inertias by expanding the shell into a solid
 
-  FaVec3 normal = (v3-v1) ^ (v4-v2);
-  double length = normal.length();
-  if (length < 1.0e-16) return false;
+  if (inertia)
+  {
+    FaVec3 normal = (v3-v1) ^ (v4-v2);
+    double length = normal.length();
+    if (length < 1.0e-16) return -2.0;
 
-  normal *= th/length;
-  v1 -= cog + 0.5*normal;
-  v2 -= cog + 0.5*normal;
-  v3 -= cog + 0.5*normal;
-  v4 -= cog + 0.5*normal;
+    normal *= th/length;
+    v1 -= cog + 0.5*normal;
+    v2 -= cog + 0.5*normal;
+    v3 -= cog + 0.5*normal;
+    v4 -= cog + 0.5*normal;
 
-  FaVec3 v5(v1+normal);
-  FaVec3 v6(v2+normal);
-  FaVec3 v7(v3+normal);
-  FaVec3 v8(v4+normal);
+    FaVec3 v5(v1+normal);
+    FaVec3 v6(v2+normal);
+    FaVec3 v7(v3+normal);
+    FaVec3 v8(v4+normal);
 
-  FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,inertia);
-  return true;
+    FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,*inertia);
+  }
+
+  return 0.5*(a1+a2)*th; // volume
 }
 
 #ifdef FF_NAMESPACE

--- a/src/FFlLib/FFlFEParts/FFlShells.H
+++ b/src/FFlLib/FFlFEParts/FFlShells.H
@@ -25,7 +25,6 @@ class FFlShellElementBase : public FFlElementBase
 {
 public:
   FFlShellElementBase(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlShellElementBase() {}
 
   double getThickness() const;
 
@@ -39,7 +38,6 @@ class FFlTRI3 : public FFlShellElementBase
 {
 public:
   FFlTRI3(int ID) : FFlShellElementBase(ID) {}
-  virtual ~FFlTRI3() {}
 
   static void init();
 
@@ -52,8 +50,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
   virtual FaVec3 mapping(double xi, double eta, double) const;
   virtual bool invertMapping(const FaVec3& X, double* Xi) const;
@@ -69,7 +66,6 @@ class FFlTRI6 : public FFlShellElementBase
 {
 public:
   FFlTRI6(int ID) : FFlShellElementBase(ID) {}
-  virtual ~FFlTRI6() {}
 
   static void init();
 
@@ -85,8 +81,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
   virtual int getNodalCoor(double* X, double* Y, double* Z) const;
 
 #ifdef FT_USE_MEMPOOL
@@ -99,7 +94,6 @@ class FFlQUAD4 : public FFlShellElementBase
 {
 public:
   FFlQUAD4(int ID) : FFlShellElementBase(ID) {}
-  virtual ~FFlQUAD4() {}
 
   static void init();
 
@@ -112,8 +106,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
   virtual FaVec3 mapping(double xi, double eta, double = 0.0) const;
   virtual bool invertMapping(const FaVec3& X, double* Xi) const;
@@ -129,7 +122,6 @@ class FFlQUAD8 : public FFlShellElementBase
 {
 public:
   FFlQUAD8(int ID) : FFlShellElementBase(ID) {}
-  virtual ~FFlQUAD8() {}
 
   static void init();
 
@@ -145,8 +137,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 #ifdef FT_USE_MEMPOOL
   FFA_MAKE_MEMPOOL;

--- a/src/FFlLib/FFlFEParts/FFlSolids.C
+++ b/src/FFlLib/FFlFEParts/FFlSolids.C
@@ -59,19 +59,20 @@ bool FFlTET4::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlTET4::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                  FFaTensor3& inertia) const
+double FFlTET4::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
   FaVec3 v3(this->getNode(3)->getPos());
   FaVec3 v4(this->getNode(4)->getPos());
 
+  double volume = 0.0;
   FFaVolume::tetVolume(v1,v2,v3,v4,volume);
   FFaVolume::tetCenter(v1,v2,v3,v4,cog);
-  FFaVolume::tetMoment(v1,v2,v3,v4,inertia);
+  if (inertia)
+    FFaVolume::tetMoment(v1,v2,v3,v4,*inertia);
 
-  return true;
+  return volume;
 }
 
 
@@ -147,8 +148,7 @@ bool FFlWEDG6::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlWEDG6::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlWEDG6::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
@@ -157,11 +157,13 @@ bool FFlWEDG6::getVolumeAndInertia(double& volume, FaVec3& cog,
   FaVec3 v5(this->getNode(5)->getPos());
   FaVec3 v6(this->getNode(6)->getPos());
 
+  double volume = 0.0;
   FFaVolume::wedVolume(v1,v2,v3,v4,v5,v6,volume);
   FFaVolume::wedCenter(v1,v2,v3,v4,v5,v6,cog);
-  FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,inertia);
+  if (inertia)
+    FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,*inertia);
 
-  return true;
+  return volume;
 }
 
 
@@ -211,8 +213,7 @@ bool FFlHEX8::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlHEX8::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                  FFaTensor3& inertia) const
+double FFlHEX8::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(2)->getPos());
@@ -223,11 +224,13 @@ bool FFlHEX8::getVolumeAndInertia(double& volume, FaVec3& cog,
   FaVec3 v7(this->getNode(7)->getPos());
   FaVec3 v8(this->getNode(8)->getPos());
 
+  double volume = 0.0;
   FFaVolume::hexVolume(v1,v2,v3,v4,v5,v6,v7,v8,volume);
   FFaVolume::hexCenter(v1,v2,v3,v4,v5,v6,v7,v8,cog);
-  FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,inertia);
+  if (inertia)
+    FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,*inertia);
 
-  return true;
+  return volume;
 }
 
 
@@ -266,8 +269,7 @@ bool FFlTET10::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlTET10::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlTET10::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   //TODO: Account for possibly curved edges
   FaVec3 v1(this->getNode(1)->getPos());
@@ -275,11 +277,13 @@ bool FFlTET10::getVolumeAndInertia(double& volume, FaVec3& cog,
   FaVec3 v3(this->getNode(5)->getPos());
   FaVec3 v4(this->getNode(10)->getPos());
 
+  double volume = 0.0;
   FFaVolume::tetVolume(v1,v2,v3,v4,volume);
   FFaVolume::tetCenter(v1,v2,v3,v4,cog);
-  FFaVolume::tetMoment(v1,v2,v3,v4,inertia);
+  if (inertia)
+    FFaVolume::tetMoment(v1,v2,v3,v4,*inertia);
 
-  return true;
+  return volume;
 }
 
 
@@ -353,8 +357,7 @@ bool FFlWEDG15::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlWEDG15::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                    FFaTensor3& inertia) const
+double FFlWEDG15::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   FaVec3 v1(this->getNode(1)->getPos());
   FaVec3 v2(this->getNode(3)->getPos());
@@ -363,11 +366,13 @@ bool FFlWEDG15::getVolumeAndInertia(double& volume, FaVec3& cog,
   FaVec3 v5(this->getNode(12)->getPos());
   FaVec3 v6(this->getNode(14)->getPos());
 
+  double volume = 0.0;
   FFaVolume::wedVolume(v1,v2,v3,v4,v5,v6,volume);
   FFaVolume::wedCenter(v1,v2,v3,v4,v5,v6,cog);
-  FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,inertia);
+  if (inertia)
+    FFaVolume::wedMoment(v1,v2,v3,v4,v5,v6,*inertia);
 
-  return true;
+  return volume;
 }
 
 
@@ -407,8 +412,7 @@ bool FFlHEX20::getFaceNormals(std::vector<FaVec3>& normals, short int face,
 }
 
 
-bool FFlHEX20::getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const
+double FFlHEX20::getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const
 {
   //TODO: Account for possibly curved egdges
   FaVec3 v1(this->getNode(1)->getPos());
@@ -420,11 +424,13 @@ bool FFlHEX20::getVolumeAndInertia(double& volume, FaVec3& cog,
   FaVec3 v7(this->getNode(17)->getPos());
   FaVec3 v8(this->getNode(19)->getPos());
 
+  double volume = 0.0;
   FFaVolume::hexVolume(v1,v2,v3,v4,v5,v6,v7,v8,volume);
   FFaVolume::hexCenter(v1,v2,v3,v4,v5,v6,v7,v8,cog);
-  FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,inertia);
+  if (inertia)
+    FFaVolume::hexMoment(v1,v2,v3,v4,v5,v6,v7,v8,*inertia);
 
-  return true;
+  return volume;
 }
 
 #ifdef FF_NAMESPACE

--- a/src/FFlLib/FFlFEParts/FFlSolids.H
+++ b/src/FFlLib/FFlFEParts/FFlSolids.H
@@ -25,7 +25,6 @@ class FFlTET4 : public FFlElementBase
 {
 public:
   FFlTET4(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlTET4() {}
 
   static void init();
 
@@ -37,8 +36,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
   virtual int checkOrientation(bool fixIt = false);
 
@@ -52,7 +50,6 @@ class FFlWEDG6 : public FFlElementBase
 {
 public:
   FFlWEDG6(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlWEDG6() {}
 
   static void init();
 
@@ -64,8 +61,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 #ifdef FT_USE_MEMPOOL
   FFA_MAKE_MEMPOOL;
@@ -77,7 +73,6 @@ class FFlHEX8 : public FFlElementBase
 {
 public:
   FFlHEX8(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlHEX8() {}
 
   static void init();
 
@@ -89,8 +84,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 #ifdef FT_USE_MEMPOOL
   FFA_MAKE_MEMPOOL;
@@ -102,7 +96,6 @@ class FFlTET10 : public FFlElementBase
 {
 public:
   FFlTET10(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlTET10() {}
 
   static void init();
 
@@ -114,8 +107,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
   virtual int checkOrientation(bool fixIt = false);
 
@@ -129,7 +121,6 @@ class FFlWEDG15 : public FFlElementBase
 {
 public:
   FFlWEDG15(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlWEDG15() {}
 
   static void init();
 
@@ -141,8 +132,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 #ifdef FT_USE_MEMPOOL
   FFA_MAKE_MEMPOOL;
@@ -154,7 +144,6 @@ class FFlHEX20 : public FFlElementBase
 {
 public:
   FFlHEX20(int ID) : FFlElementBase(ID) {}
-  virtual ~FFlHEX20() {}
 
   static void init();
 
@@ -166,8 +155,7 @@ public:
   virtual bool getFaceNormals(std::vector<FaVec3>& normals, short int face = 1,
                               bool switchNormal = false) const;
 
-  virtual bool getVolumeAndInertia(double& volume, FaVec3& cog,
-                                   FFaTensor3& inertia) const;
+  virtual double getVolumeAndCoG(FaVec3& cog, FFaTensor3* inertia) const;
 
 #ifdef FT_USE_MEMPOOL
   FFA_MAKE_MEMPOOL;

--- a/src/FFlLib/FFlLinkHandler.C
+++ b/src/FFlLib/FFlLinkHandler.C
@@ -436,36 +436,30 @@ bool FFlLinkHandler::updateCalculationFlag(int groupID, bool status)
 
 bool FFlLinkHandler::updateCalculationFlag(FFlPartBase* part, bool status)
 {
-  FFlGroup* tmpGroup = dynamic_cast<FFlGroup*>(part);
-  if (tmpGroup) {
-    for (const GroupElemRef& elm : *tmpGroup)
+  if (FFlGroup* group = dynamic_cast<FFlGroup*>(part); group)
+  {
+    for (const GroupElemRef& elm : *group)
       elm->setUpForCalculations(status);
-    return true;
   }
-
-  FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part);
-  if (attr) {
+  else if (FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part); attr)
+  {
     for (FFlElementBase* elm : myElements)
       if (elm->hasAttribute(attr))
         elm->setUpForCalculations(status);
-    return true;
   }
-
-  FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part);
-  if (elm) {
+  else if (FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part); elm)
     elm->setUpForCalculations(status);
-    return true;
-  }
+  else
+    return false;
 
-  return false;
+  return true;
 }
 
 
 bool FFlLinkHandler::updateCalculationFlag(const std::string& type,
                                            int id, bool status)
 {
-  FFlAttributeBase* attrib = this->getAttribute(type,id);
-  if (attrib)
+  if (FFlAttributeBase* attrib = this->getAttribute(type,id); attrib)
     return this->updateCalculationFlag(attrib,status);
   else
     return false;
@@ -521,28 +515,23 @@ bool FFlLinkHandler::setVisDetail(const FFlVDetail* detail)
 
 bool FFlLinkHandler::setVisDetail(FFlPartBase* part, const FFlVDetail* detail)
 {
-  FFlGroup* tmpGroup = dynamic_cast<FFlGroup*>(part);
-  if (tmpGroup) {
-    for (const GroupElemRef& elm : *tmpGroup)
+  if (FFlGroup* group = dynamic_cast<FFlGroup*>(part); group)
+  {
+    for (const GroupElemRef& elm : *group)
       elm->setDetail(detail);
-    return true;
   }
-
-  FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part);
-  if (attr) {
+  else if (FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part); attr)
+  {
     for (FFlElementBase* elm : myElements)
       if (elm->hasAttribute(attr))
         elm->setDetail(detail);
-    return true;
   }
-
-  FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part);
-  if (elm) {
+  else if (FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part); elm)
     elm->setDetail(detail);
-    return true;
-  }
+  else
+    return false;
 
-  return false;
+  return true;
 }
 
 
@@ -551,25 +540,14 @@ bool FFlLinkHandler::setVisDetail(const std::vector<FFlPartBase*>& parts,
 {
   std::vector<FFlAttributeBase*> attribParts;
 
-  for (FFlPartBase* part : parts)
-  {
-    FFlGroup* tmpGroup = dynamic_cast<FFlGroup*>(part);
-    if (tmpGroup)
-      for (const GroupElemRef& elm : *tmpGroup)
+  for (FFlPartBase* pt : parts)
+    if (FFlGroup* group = dynamic_cast<FFlGroup*>(pt); group)
+      for (const GroupElemRef& elm : *group)
         elm->setDetail(detail);
-    else
-    {
-      FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part);
-      if (attr)
-        attribParts.push_back(attr);
-      else
-      {
-        FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part);
-        if (elm)
-          elm->setDetail(detail);
-      }
-    }
-  }
+    else if (FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(pt); attr)
+      attribParts.push_back(attr);
+    else if (FFlElementBase* elm = dynamic_cast<FFlElementBase*>(pt); elm)
+      elm->setDetail(detail);
 
   if (!attribParts.empty())
     for (FFlElementBase* elm : myElements)
@@ -584,28 +562,23 @@ bool FFlLinkHandler::setVisDetail(const std::vector<FFlPartBase*>& parts,
 bool FFlLinkHandler::setVisAppearance(FFlPartBase* part,
                                       const FFlVAppearance* app)
 {
-  FFlGroup* tmpGroup = dynamic_cast<FFlGroup*>(part);
-  if (tmpGroup) {
-    for (const GroupElemRef& elm : *tmpGroup)
+  if (FFlGroup* group = dynamic_cast<FFlGroup*>(part); group)
+  {
+    for (const GroupElemRef& elm : *group)
       elm->setAppearance(app);
-    return true;
   }
-
-  FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part);
-  if (attr) {
+  else if (FFlAttributeBase* attr = dynamic_cast<FFlAttributeBase*>(part); attr)
+  {
     for (FFlElementBase* elm : myElements)
       if (elm->hasAttribute(attr))
         elm->setAppearance(app);
-    return true;
   }
-
-  FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part);
-  if (elm) {
+  else if (FFlElementBase* elm = dynamic_cast<FFlElementBase*>(part); elm)
     elm->setAppearance(app);
-    return true;
-  }
+  else
+    return false;
 
-  return false;
+  return true;
 }
 #endif
 
@@ -701,9 +674,9 @@ void FFlLinkHandler::addVisual(FFlVisualBase* visual, bool sortOnInsert)
 
 void FFlLinkHandler::setRunningIdxOnAppearances()
 {
-  FFlVAppearance* vapp = NULL; int idx = 0;
+  int idx = 0;
   for (FFlVisualBase* vis : myVisuals)
-    if ((vapp = dynamic_cast<FFlVAppearance*>(vis)))
+    if (FFlVAppearance* vapp = dynamic_cast<FFlVAppearance*>(vis); vapp)
       vapp->runningIdx = idx++;
 }
 #endif
@@ -769,14 +742,13 @@ FFlVAppearance* FFlLinkHandler::getAppearance(int ID) const
                                                         myVisuals.end(), ID,
                                                         FFlFEPartBaseLess());
 
-  FFlVAppearance* vapp = NULL;
   while (ep.first != ep.second)
-    if ((vapp = dynamic_cast<FFlVAppearance*>(*ep.first)))
-      break;
+    if (FFlVAppearance* vapp = dynamic_cast<FFlVAppearance*>(*ep.first); vapp)
+      return vapp;
     else
       ep.first++;
 
-  return vapp;
+  return NULL;
 }
 
 
@@ -788,14 +760,13 @@ FFlVDetail* FFlLinkHandler::getDetail(int ID) const
                                                         myVisuals.end(), ID,
                                                         FFlFEPartBaseLess());
 
-  FFlVDetail* vdet = NULL;
   while (ep.first != ep.second)
-    if ((vdet = dynamic_cast<FFlVDetail*>(*ep.first)))
-      break;
+    if (FFlVDetail* vdet = dynamic_cast<FFlVDetail*>(*ep.first); vdet)
+      return vdet;
     else
       ep.first++;
 
-  return vdet;
+  return NULL;
 }
 #endif
 
@@ -1217,7 +1188,7 @@ bool FFlLinkHandler::addGroup(FFlGroup* group, bool silence)
 {
   if (!group) return false;
 
-  if (myGroupMap.insert({group->getID(),group}).second)
+  if (myGroupMap.emplace(group->getID(),group).second)
   {
     isResolved = false;
     return true;
@@ -1237,7 +1208,7 @@ bool FFlLinkHandler::addAttribute(FFlAttributeBase* attr, bool silence,
 {
   if (!attr) return false;
 
-  if (myAttributes[name].insert({attr->getID(),attr}).second)
+  if (myAttributes[name].emplace(attr->getID(),attr).second)
   {
     isResolved = false;
     return true;
@@ -1334,13 +1305,12 @@ bool FFlLinkHandler::removeAttribute(const std::string& typeName,
 
 FFlVDetail* FFlLinkHandler::getPredefDetail(int detailType)
 {
-  FFlVDetail* vdet = NULL;
   for (FFlVisualBase* vis : myVisuals)
-    if ((vdet = dynamic_cast<FFlVDetail*>(vis)))
+    if (FFlVDetail* vdet = dynamic_cast<FFlVDetail*>(vis); vdet)
       if (vdet->detail.getValue() == detailType)
 	return vdet;
 
-  vdet = new FFlVDetail(this->getNewVisualID());
+  FFlVDetail* vdet = new FFlVDetail(this->getNewVisualID());
   vdet->detail.setValue(detailType);
   this->addVisual(vdet,true);
 
@@ -1371,10 +1341,9 @@ void FFlLinkHandler::getAllInternalCoordSys(std::vector<FaMat34>& mxes) const
   AttributeTypeCIter mapit = myAttributes.find("PCOORDSYS");
   if (mapit == myAttributes.end()) return;
 
-  FFlPCOORDSYS* lcs;
   mxes.reserve(mapit->second.size());
   for (const AttributeMap::value_type& attr : mapit->second)
-    if ((lcs = dynamic_cast<FFlPCOORDSYS*>(attr.second)))
+    if (FFlPCOORDSYS* lcs = dynamic_cast<FFlPCOORDSYS*>(attr.second); lcs)
     {
       mxes.push_back(FaMat34());
       mxes.back().makeCS_Z_XZ(lcs->Origo.getValue(),
@@ -1410,14 +1379,13 @@ FFlNode* FFlLinkHandler::findFreeNodeAtPoint(const FaVec3& point,
   FFlNode* closest = NULL;
   double closestdist = DBL_MAX;
   double sqrTol = tol > sqrt(DBL_MAX) ? DBL_MAX : tol*tol;
-  double sqrdist, xd, yd, zd;
 
   for (FFlNode* node : myNodes)
     if (node->hasDOFs(dofFilter) || node->isExternal() || node->isRefNode())
-      if ((xd = fabs(node->getPos().x() - point.x())) < tol)
-        if ((yd = fabs(node->getPos().y() - point.y())) < tol)
-          if ((zd = fabs(node->getPos().z() - point.z())) < tol)
-            if ((sqrdist = xd*xd+yd*yd+zd*zd) < sqrTol)
+      if (double xd = fabs(node->getPos().x() - point.x()); xd < tol)
+        if (double yd = fabs(node->getPos().y() - point.y()); yd < tol)
+          if (double zd = fabs(node->getPos().z() - point.z()); zd < tol)
+            if (double sqrdist = xd*xd+yd*yd+zd*zd; sqrdist < sqrTol)
             {
               if (closestdist >= sqrTol)
               {
@@ -1617,13 +1585,12 @@ FFlNode* FFlLinkHandler::findClosestNode(const FaVec3& point) const
 {
   FFlNode* closest = NULL;
   double closestdist = DBL_MAX;
-  double sqrdist;
 
   for (FFlNode* node : myNodes)
-    if ((sqrdist = (point - node->getPos()).sqrLength()) <= closestdist)
+    if (double d2 = (point - node->getPos()).sqrLength(); d2 <= closestdist)
     {
       closest     = node;
-      closestdist = sqrdist;
+      closestdist = d2;
     }
 
   return closest;
@@ -1641,19 +1608,18 @@ FFlElementBase* FFlLinkHandler::findClosestElement(const FaVec3& point,
 {
   FFlElementBase* closest = NULL;
   double closestdist = DBL_MAX;
-  double sqrdist;
 
   // OTHER_ELM = the total number of element cathegories
   std::vector<bool> typeOk(FFlTypeInfoSpec::OTHER_ELM+1,wantedTypes.empty());
   for (FFlTypeInfoSpec::Cathegory type : wantedTypes)
     typeOk[type] = true;
 
-  for (FFlElementBase* elm : myElements)
-    if (typeOk[elm->getCathegory()])
-      if ((sqrdist = (point - elm->getNodeCenter()).sqrLength()) <= closestdist)
+  for (FFlElementBase* e : myElements)
+    if (typeOk[e->getCathegory()])
+      if (double d2 = (point - e->getNodeCenter()).sqrLength(); d2 <= closestdist)
       {
-        closest     = elm;
-        closestdist = sqrdist;
+        closest     = e;
+        closestdist = d2;
       }
 
   return closest;
@@ -1670,13 +1636,12 @@ FFlElementBase* FFlLinkHandler::findClosestElement(const FaVec3& point,
 {
   FFlElementBase* closest = NULL;
   double closestdist = DBL_MAX;
-  double sqrdist;
 
-  for (const GroupElemRef& elm : group)
-    if ((sqrdist = (point - elm->getNodeCenter()).sqrLength()) <= closestdist)
+  for (const GroupElemRef& e : group)
+    if (double d2 = (point - e->getNodeCenter()).sqrLength(); d2 <= closestdist)
     {
-      closest     = elm.getReference();
-      closestdist = sqrdist;
+      closest     = e.getReference();
+      closestdist = d2;
     }
 
   return closest;
@@ -1820,15 +1785,10 @@ void FFlLinkHandler::findWindowedNodes(std::map<int,FaVec3>& nodes,
   int nVertices = myVertices.size();
   for (int idx : indices)
     if (idx < nVertices && visited.insert(idx).second)
-    {
-      const FFlVertex* vrtx = static_cast<const FFlVertex*>(myVertices[idx]);
-      if (vrtx && vrtx->getNode())
-      {
-        FaVec3 globalPos = lCS * (*vrtx);
-        if (isInsideWindow(globalPos))
-          nodes[vrtx->getNode()->getID()] = globalPos;
-      }
-    }
+      if (const FFlVertex* vx = static_cast<const FFlVertex*>(myVertices[idx]);
+          vx && vx->getNode())
+        if (FaVec3 globalPos = lCS * (*vx); isInsideWindow(globalPos))
+          nodes[vx->getNode()->getID()] = globalPos;
 }
 
 #endif
@@ -1945,10 +1905,9 @@ bool FFlLinkHandler::resolve(bool subdivParabolic, bool fromSESAM)
                  << attr.second->getID() <<" failed\n";
 
   // Remove loose nodes from WAVGM and RGD elements
-  int nNod = 0;
   ElementsVec toBeErased;
   for (FFlElementBase* elm : myElements)
-    if ((nNod = elm->getNodeCount()) < 1)
+    if (int nNod = elm->getNodeCount(); nNod < 1)
       toBeErased.push_back(elm);
     else if (elm->getTypeName() == "WAVGM")
     {
@@ -1983,7 +1942,15 @@ bool FFlLinkHandler::resolve(bool subdivParabolic, bool fromSESAM)
         continue;
       }
 
-      (*refn)->pushDOFs(6); // Ensure the reference node is not flagged DOF-less
+      FFlAttributeBase* pAtt = elm->getAttribute("PWAVGM");
+
+      // Ensure the reference node is not flagged DOF-less.
+      // Issue fedem-solvers#49: Don't enforce rotational DOFs on the reference
+      // node if the constraint element couples translational DOFs only.
+      if (pAtt && abs(static_cast<FFlPWAVGM*>(pAtt)->refC.getValue()) < 322)
+        (*refn)->pushDOFs(3);
+      else
+        (*refn)->pushDOFs(6);
 
       if (looseNodes.empty()) continue;
 
@@ -1992,18 +1959,16 @@ bool FFlLinkHandler::resolve(bool subdivParabolic, bool fromSESAM)
              <<" loose nodes from WAVGM element "<< elm->getID();
       if (!static_cast<FFlWAVGM*>(elm)->removeMasterNodes(looseNodes))
         ++nError;
-      else
+      else if (pAtt)
       {
-        FFlAttributeBase* newAtt = elm->getAttribute("PWAVGM");
-        if (newAtt)
-        {
-          int ID = 1;
-          while (this->getAttribute("PWAVGM",ID)) ID++;
-          newAtt = static_cast<FFlPWAVGM*>(newAtt)->removeWeights(looseNodes,nNod);
-          newAtt->setID(ID);
-          elm->clearAttribute("PWAVGM"); // Replace the old attribute with the new one
-          elm->setAttribute(this->getAttribute("PWAVGM",this->addUniqueAttribute(newAtt)));
-        }
+        int ID = 1;
+        while (this->getAttribute("PWAVGM",ID)) ID++;
+        pAtt = static_cast<FFlPWAVGM*>(pAtt)->removeWeights(looseNodes,nNod);
+        pAtt->setID(ID);
+        // Replace the old attribute with the new one
+        elm->clearAttribute("PWAVGM");
+        ID = this->addUniqueAttribute(pAtt);
+        elm->setAttribute(this->getAttribute("PWAVGM",ID));
       }
     }
     else if (elm->getTypeName() == "RGD")
@@ -2419,7 +2384,6 @@ int FFlLinkHandler::createConnector(const FFaCompoundGeometry& compound,
   cItems.clear();
 
   FFlNode* refNode = new FFlNode(this->getNewNodeID(),nodePos);
-  refNode->pushDOFs(6);
   this->addNode(refNode,true);
   cItems.addNode(refNode->getID());
   ListUI <<"  -> Creating FE node "<< refNode->getID() <<"\n";

--- a/src/FFlLib/FFlLinkHandler.H
+++ b/src/FFlLib/FFlLinkHandler.H
@@ -96,10 +96,11 @@ public:
   bool addGroup(FFlGroup* group, bool silence = false);
   void addLoad(FFlLoadBase* load, bool sortOnInsert = false);
   bool addAttribute(FFlAttributeBase* attr, bool silence = false);
-  bool addAttribute(FFlAttributeBase* attr, bool silence, const std::string& name);
+  bool addAttribute(FFlAttributeBase* attr, bool silence,
+                    const std::string& name);
   int  addUniqueAttribute(FFlAttributeBase* attr, bool silence = false);
   int  addUniqueAttributeCS(FFlAttributeBase*& attr);
-  bool removeAttribute(const std::string& typeName, int ID, bool silence = false);
+  bool removeAttribute(const std::string& name, int ID, bool silence = false);
 #ifdef FT_USE_VISUALS
   void addVisual(FFlVisualBase* visual, bool sortOnInsert = false);
   void setRunningIdxOnAppearances();
@@ -138,10 +139,12 @@ public:
   bool getLoads(int ID, LoadsVec& loads) const;
   void getLoadCases(std::set<int>& IDs) const;
 
-  // External-to-internal node and (finite) element number mapping
+  //! \brief External-to-internal node number mapping.
   int getIntNodeID(int extID) const;
+  //! \brief External-to-internal (finite) element number mapping.
   int getIntElementID(int extID) const;
 
+  //! \brief Removes the given elements from the myElements container.
   void removeElements(const ElementsVec& elms);
 
   int getNewElmID() const;
@@ -197,12 +200,10 @@ public:
   const FFlrVxToElmMap& getVxToElementMapping();
 
   using WindowTester = bool(*)(const FaVec3&);
-
   void findWindowedNodes(std::map<int,FaVec3>& nodes,
                          const std::vector<int>& indices,
                          const FaMat34& lCS, bool lFirst,
                          WindowTester isInsideWindow) const;
-
 #endif
 
   void getAllInternalCoordSys(std::vector<FaMat34>& mxes) const;
@@ -274,13 +275,15 @@ public:
   void initiateCalculationFlag(bool status = false);
   bool updateCalculationFlag(int groupId, bool status = true);
   bool updateCalculationFlag(FFlPartBase* part, bool status = true);
-  bool updateCalculationFlag(const std::string& attType, int id, bool status = true);
+  bool updateCalculationFlag(const std::string& attType, int id,
+                             bool status = true);
 
 #ifdef FT_USE_VISUALS
   // Visual settings
   bool setVisDetail(const FFlVDetail* det); // on all elements
   bool setVisDetail(FFlPartBase* part, const FFlVDetail* det);
-  bool setVisDetail(const std::vector<FFlPartBase*>& parts, const FFlVDetail* det);
+  bool setVisDetail(const std::vector<FFlPartBase*>& parts,
+                    const FFlVDetail* det);
   bool setVisAppearance(FFlPartBase* partSpec, const FFlVAppearance* app);
   void updateGroupVisibilityStatus();
 

--- a/src/FFlLib/FFlLinkHandler_F.C
+++ b/src/FFlLib/FFlLinkHandler_F.C
@@ -42,13 +42,6 @@
 using namespace FF_NAMESPACE;
 #endif
 
-//! \brief Pointers to all FE parts subjected to recovery during dynamics solve
-static std::vector<FFlLinkHandler*> ourLinks;
-//! \brief Pointer to FE part currently in calculation focus
-static FFlLinkHandler* ourLink = NULL;
-//! \brief Pointer to FFaCheckSum object for FE part in calculation focus
-static FFaCheckSum* chkSum = NULL;
-
 //! \brief Convenience macro for dynamic casting of an element attribute pointer
 #define GET_ATTRIBUTE(el,att) dynamic_cast<FFl##att*>((el)->getAttribute(#att))
 //! \brief Convenience macro for dynamic casting of a link attribute pointer
@@ -56,73 +49,148 @@ static FFaCheckSum* chkSum = NULL;
   ourLink ? dynamic_cast<FFl##att*>(ourLink->getAttribute(#att,ID)) : NULL
 
 
-////////////////////////////////////////////////////////////////////////////////
-//! \brief Initializes the FE part object #ourLink by reading data from file.
-//! \details Common function used both by the Reducer and the Recovery modules.
-//!
-//! \author Jens Lien
-//! \date Apr 2003
-
-static int ffl_basic_init (int maxNodes, int maxElms,
-                           const std::string& partName = "")
+namespace
 {
-  std::string linkFile;
-  if (partName.empty())
-    FFaCmdLineArg::instance()->getValue("linkfile",linkFile);
-  else
-    linkFile = partName;
+  //! Pointers to all FE parts subjected to recovery during dynamics solve
+  std::vector<FFlLinkHandler*> ourLinks;
+  //! Pointer to FE part currently in calculation focus
+  FFlLinkHandler* ourLink = NULL;
+  //! Pointer to a FFaCheckSum object for the FE part in calculation focus
+  FFaCheckSum* chkSum = NULL;
 
-  if (linkFile.empty())
+  //////////////////////////////////////////////////////////////////////////////
+  //! \brief Common function initializing the FE part object #ourLink.
+  //! \detail This function is used both by the FE Part Reducer and the
+  //! FE Recovery modules, and initializes the FFlLinkHandler object by reading
+  //! data from the file specified through the command-line option `-linkfile`.
+  //!
+  //! \author Jens Lien
+  //! \date Apr 2003
+
+  int ffl_basic_init (int maxNod, int maxElm, const std::string& partName = "")
   {
-    ListUI <<" *** Error: FE data file must be specified through -linkfile\n";
-    return -1;
+    std::string linkFile;
+    if (partName.empty())
+      FFaCmdLineArg::instance()->getValue("linkfile",linkFile);
+    else
+      linkFile = partName;
+
+    if (linkFile.empty())
+    {
+      ListUI <<" *** Error: FE data file must be specified through -linkfile\n";
+      return -1;
+    }
+
+    if (ourLink && partName.empty())
+    {
+      std::cerr <<"ffl_init: Logic error, FE part already exists"<< std::endl;
+      return -99;
+    }
+
+    if (!(ourLink = new FFlLinkHandler(maxNod,maxElm)))
+    {
+      std::cerr <<"ffl_init: Error allocating FE part object"<< std::endl;
+      return -2;
+    }
+
+    FFl::initAllReaders();
+    FFl::initAllElements();
+
+    // Read the FE data file into the FFlLinkHandler object
+    FFaFilePath::checkName(linkFile);
+    FFlFedemReader::ignoreCheckSum = !partName.empty();
+    if (FFlReaders::instance()->read(linkFile,ourLink) > 0)
+    {
+      ourLinks.push_back(ourLink);
+      return partName.empty() ? 0 : ourLinks.size();
+    }
+
+    if (ourLink->isTooLarge())
+      ListUI <<" *** FE reduction and recovery is only a demo feature\n    "
+             <<" with the current license, and limited to small models only.\n"
+             <<"     To continue with the current model, you may toggle this"
+             <<" part into a Generic Part before solving.\n";
+
+    delete ourLink;
+    ourLink = NULL;
+    return -3;
   }
 
-  if (ourLink && partName.empty())
+  //////////////////////////////////////////////////////////////////////////////
+  //! \brief Auxiliary function returning a pointer to an indexed element.
+  //!
+  //! \author Knut Morten Okstad
+  //! \date 18 Sep 2002
+
+  FFlElementBase* ffl_getElement (int iel)
   {
-    std::cerr <<"ffl_init: Logic error, FE part already exists"<< std::endl;
-    return -99;
+    if (!ourLink)
+      std::cerr <<"ffl_getElement: FE part object not initialized"<< std::endl;
+    else if (FFlElementBase* elm = ourLink->getFiniteElement(iel); elm)
+      return elm;
+    else
+      ListUI <<" *** Error: Invalid element index "<< iel <<", out of range [1,"
+             << ourLink->getElementCount(FFlLinkHandler::FFL_FEM) <<"]\n";
+
+    return NULL;
   }
 
-  ourLink = new FFlLinkHandler(maxNodes,maxElms);
-  if (!ourLink)
+#ifdef FT_USE_STRAINCOAT
+  //////////////////////////////////////////////////////////////////////////////
+  //! \brief Auxiliary function for retrieval of strain coat attributes.
+  //!
+  //! \author Knut Morten Okstad
+  //! \date 28 May 2001
+
+  void getStrainCoatAttributes (FFlPSTRC* p, FFlPFATIGUE* pFat,
+                                int& resSet, int& id,
+                                double& E, double& nu, double& Z,
+                                int& SNstd, int& SNcurve, double& SCF)
   {
-    std::cerr <<"ffl_init: Error allocating FE part object"<< std::endl;
-    return -2;
+    resSet = id = 0;
+    E = nu = Z = SCF = 0.0;
+    SNstd = SNcurve = -1;
+    if (!p) return;
+
+    const std::string& name = p->name.getValue();
+    if (name == "Bottom")
+      resSet = 1;
+    else if (name == "Mid")
+      resSet = 2;
+    else if (name == "Top")
+      resSet = 3;
+
+    if (FFlPMAT* curMat = GET_ATTRIBUTE(p,PMAT); curMat)
+    {
+      id = curMat->getID();
+      E  = curMat->youngsModule.getValue();
+      nu = curMat->poissonsRatio.getValue();
+    }
+
+    if (FFlPHEIGHT* curHeight = GET_ATTRIBUTE(p,PHEIGHT); curHeight)
+      Z = curHeight->height.getValue();
+    else if (FFlPTHICKREF* curTref = GET_ATTRIBUTE(p,PTHICKREF); curTref)
+      if (FFlPTHICK* curThk = GET_ATTRIBUTE(curTref,PTHICK); curThk)
+        Z = curThk->thickness.getValue() * curTref->factor.getValue();
+
+    if (pFat)
+    {
+      SNstd = pFat->snCurveStd.getValue();
+      SNcurve = pFat->snCurveIndex.getValue();
+      SCF = pFat->stressConcentrationFactor.getValue();
+    }
   }
-
-  FFl::initAllReaders();
-  FFl::initAllElements();
-
-  // Read the FE data file into the FFlLinkHandler object
-  FFaFilePath::checkName(linkFile);
-  FFlFedemReader::ignoreCheckSum = !partName.empty();
-  if (FFlReaders::instance()->read(linkFile,ourLink) > 0)
-  {
-    ourLinks.push_back(ourLink);
-    return partName.empty() ? 0 : ourLinks.size();
-  }
-
-  if (ourLink->isTooLarge())
-    ListUI <<" *** Reduction and recovery of FE parts is only a demo feature\n"
-	   <<"     with the current license, and therefore limited to small"
-	   <<" models only.\n"
-	   <<"     To continue with the current model, you may toggle this part"
-	   <<"  into a Generic Part before solving.\n";
-
-  delete ourLink;
-  ourLink = NULL;
-  return -3;
-}
+#endif
+} // end anonynous namespace
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Allocate the FE part object and read FE data file. Then optionally set
-// the calculation flag for elements belonging to the user-specified groups.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Allocates the FE part object and read FE data file.
+//! \details Then optionally set the calculation flag for elements
+//! belonging to the user-specified groups.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_limited_init,FFL_LIMITED_INIT) (const int& maxNodes,
 					       const int& maxElms,
@@ -147,12 +215,12 @@ SUBROUTINE(ffl_limited_init,FFL_LIMITED_INIT) (const int& maxNodes,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Allocate the FE part object and read FE data file. Then set
-// the calculation flag for elements belonging to the user-specified groups.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 26 Oct 2015 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Allocates the FE part object and reads FE data file.
+//! \details Then set the calculation flag for elements
+//! belonging to the user-specified groups.
+//!
+//! \author Knut Morten Okstad
+//! \date 26 Oct 2015
 
 SUBROUTINE(ffl_full_init,FFL_FULL_INIT) (const char* linkFile,
 					 const char* elmGroups,
@@ -171,13 +239,12 @@ SUBROUTINE(ffl_full_init,FFL_FULL_INIT) (const char* linkFile,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Allocate the FE part object and read FE data file. Then optionally set
-// the external nodes based on the command line options. Also export the
-// new complete FTL file if specified.
-//
-// Coded by: Jens Lien
-// Date/ver: Apr 2003 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Allocates the FE part object and reads FE data file.
+//! \details Then optionally set the external nodes based on the command-line
+//! options. Also export the new complete FTL file, if requested.
+//!
+//! \author Jens Lien
+//! \date Apr 2003
 
 SUBROUTINE(ffl_reducer_init,FFL_REDUCER_INIT) (const int& maxNodes,
 					       const int& maxElms,
@@ -206,16 +273,12 @@ SUBROUTINE(ffl_reducer_init,FFL_REDUCER_INIT) (const int& maxNodes,
     else
       nodeID.push_back(atoi(extNodes.c_str()));
 
-    if (!nodeID.empty())
-    {
-      FFlNode* theNode;
-      for (int nId : nodeID)
-        if ((theNode = ourLink->getNode(nId)))
-          theNode->setExternal();
-        else
-          ListUI <<"  ** Warning: Non-existing external node "<< nId
-                 <<" (ignored)\n";
-    }
+    for (int nId : nodeID)
+      if (FFlNode* theNode = ourLink->getNode(nId); theNode)
+        theNode->setExternal();
+      else
+        ListUI <<"  ** Warning: Non-existing external node "<< nId
+               <<" (ignored)\n";
   }
 
   std::string ftlOut;
@@ -228,11 +291,10 @@ SUBROUTINE(ffl_reducer_init,FFL_REDUCER_INIT) (const int& maxNodes,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Sets calculation focus on an already open FE part.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 26 Oct 2015 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Sets calculation focus on an already open FE part.
+//!
+//! \author Knut Morten Okstad
+//! \date 26 Oct 2015
 
 SUBROUTINE(ffl_set,FFL_SET) (const int& linkIdx)
 {
@@ -247,11 +309,10 @@ SUBROUTINE(ffl_set,FFL_SET) (const int& linkIdx)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Release the FE part object(s).
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Releases the FE part object(s).
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_release,FFL_RELEASE) (const int& removeSingletons)
 {
@@ -272,12 +333,11 @@ SUBROUTINE(ffl_release,FFL_RELEASE) (const int& removeSingletons)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Export the FE part geometry to the specified VTF file.
-// The specified VTF file must already exist.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 17 January 2006 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Exports the FE part geometry to the specified VTF file.
+//! \details The specified VTF file must already exist.
+//!
+//! \author Knut Morten Okstad
+//! \date 17 January 2006
 
 SUBROUTINE(ffl_export_vtf,FFL_EXPORT_VTF) (const char* VTFfile,
 					   const char* linkName,
@@ -299,12 +359,11 @@ SUBROUTINE(ffl_export_vtf,FFL_EXPORT_VTF) (const char* VTFfile,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Sort the elements in the alphabetic order of the element types.
-// This is the order the elements are written out to the VTF file.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 17 March 2006 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Sorts the elements in the alphabetic order of the element types.
+//! \details This is the order the elements are written out to the VTF file.
+//!
+//! \author Knut Morten Okstad
+//! \date 17 March 2006
 
 SUBROUTINE(ffl_elmorder_vtf,FFL_ELMORDER_VTF) (int* vtfOrder, int& stat)
 {
@@ -336,11 +395,10 @@ SUBROUTINE(ffl_elmorder_vtf,FFL_ELMORDER_VTF) (int* vtfOrder, int& stat)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Compute global mass properties for the FE part.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 27 Jun 2005 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Computes global mass properties for the FE part.
+//!
+//! \author Knut Morten Okstad
+//! \date 27 Jun 2005
 
 SUBROUTINE(ffl_massprop,FFL_MASSPROP) (double& mass, double* cg, double* II)
 {
@@ -355,11 +413,10 @@ SUBROUTINE(ffl_massprop,FFL_MASSPROP) (double& mass, double* cg, double* II)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return some model size parameters.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Calculates some model size parameters.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getsize,FFL_GETSIZE) (int& nnod, int& nel, int& ndof, int& nmnpc,
                                      int& nmat, int& nxnod, int& npbeam,
@@ -395,8 +452,7 @@ SUBROUTINE(ffl_getsize,FFL_GETSIZE) (int& nnod, int& nel, int& ndof, int& nmnpc,
     if (curTyp == "BEAM2")
     {
       // Add extra nodes for beams with pin flags
-      FFlPBEAMPIN* myPin = GET_ATTRIBUTE(*eit,PBEAMPIN);
-      if (myPin)
+      if (FFlPBEAMPIN* myPin = GET_ATTRIBUTE(*eit,PBEAMPIN); myPin)
       {
         npbeam++;
         if (myPin->PA.getValue() > 0) nxnod++;
@@ -423,11 +479,10 @@ SUBROUTINE(ffl_getsize,FFL_GETSIZE) (int& nnod, int& nel, int& ndof, int& nmnpc,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Establish global nodal arrays needed by SAM.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Establishes the global nodal arrays needed by SAM.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getnodes,FFL_GETNODES) (const int& nnod, int& ndof, int* madof,
                                        int* minex, int* mnode, int* msc,
@@ -525,7 +580,7 @@ SUBROUTINE(ffl_getnodes,FFL_GETNODES) (const int& nnod, int& ndof, int* madof,
         if (!resolvePinFlag(nit->getReference(),myPin->PA.getValue(),msc+ndof))
           ierr--;
 
-	++nit;
+        ++nit;
         if (!resolvePinFlag(nit->getReference(),myPin->PB.getValue(),msc+ndof))
           ierr--;
       }
@@ -533,11 +588,10 @@ SUBROUTINE(ffl_getnodes,FFL_GETNODES) (const int& nnod, int& ndof, int* madof,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Establish element type and global topology arrays needed by SAM.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Establishes element type and global topology arrays needed by SAM.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_gettopol,FFL_GETTOPOL) (int& nel, int& nmnpc,
                                        int* mekn, int* mmnpc, int* mpmnpc,
@@ -653,31 +707,12 @@ SUBROUTINE(ffl_gettopol,FFL_GETTOPOL) (int& nel, int& nmnpc,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-//! \brief Auxiliary function returning a pointer to and indexed element object.
+//! \brief Returns the external ID for a given internal element number.
+//! \details A negative value is returned if post-processing calculations
+//! should be skipped for this element.
 //!
 //! \author Knut Morten Okstad
-//! \date 18 Sep 2002
-
-static FFlElementBase* ffl_getElement (int iel)
-{
-  FFlElementBase* curElm = NULL;
-  if (!ourLink)
-    std::cerr <<"ffl_getElement: Internal error, ourLink is NULL"<< std::endl;
-  else if (!(curElm = ourLink->getFiniteElement(iel)))
-    ListUI <<" *** Error: Invalid element index "<< iel <<", out of range [1,"
-           << ourLink->getElementCount(FFlLinkHandler::FFL_FEM) <<"]\n";
-
-  return curElm;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Get external ID for a given internal element number.
-// Negative if post-processing calculations should be skipped for this element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Oct 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \date 20 Oct 2000
 
 INTEGER_FUNCTION(ffl_getelmid,FFL_GETELMID) (const int& iel)
 {
@@ -690,11 +725,10 @@ INTEGER_FUNCTION(ffl_getelmid,FFL_GETELMID) (const int& iel)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return the internal node/element number for the given external ID.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 14 Nov 2005 / 2.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns the internal node/element number for the given external ID.
+//!
+//! \author Knut Morten Okstad
+//! \date 14 Nov 2005
 
 INTEGER_FUNCTION(ffl_ext2int,FFL_EXT2INT) (const int& nodeID, const int& ID)
 {
@@ -702,7 +736,7 @@ INTEGER_FUNCTION(ffl_ext2int,FFL_EXT2INT) (const int& nodeID, const int& ID)
 
   int intID = -1;
   if (!ourLink)
-    std::cerr <<"ffl_ext2int: Internal error, ourLink is NULL"<< std::endl;
+    std::cerr <<"ffl_ext2int: FE part object not initialized"<< std::endl;
   else if (ID < 0)
     intID = 0;
   else if (nodeID)
@@ -719,11 +753,10 @@ INTEGER_FUNCTION(ffl_ext2int,FFL_EXT2INT) (const int& nodeID, const int& ID)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get global nodal coordinates for an element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets global nodal coordinates for an element.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getcoor,FFL_GETCOOR) (double* X, double* Y, double* Z,
                                      const int& iel, int& ierr)
@@ -734,11 +767,10 @@ SUBROUTINE(ffl_getcoor,FFL_GETCOOR) (double* X, double* Y, double* Z,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get material data for an element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets material data for an element.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getmat,FFL_GETMAT) (double& E, double& nu, double& rho,
                                    const int& iel, int& ierr)
@@ -771,8 +803,7 @@ SUBROUTINE(ffl_getmat,FFL_GETMAT) (double& E, double& nu, double& rho,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Check if an element has a certain attribute
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Checks if an element has a certain attribute.
 
 SUBROUTINE(ffl_attribute,FFL_ATTRIBUTE) (const char* type,
 #ifdef _NCHAR_AFTER_CHARARG
@@ -794,8 +825,7 @@ SUBROUTINE(ffl_attribute,FFL_ATTRIBUTE) (const char* type,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get composite data
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns the number of composite data objects.
 
 INTEGER_FUNCTION(ffl_getmaxcompositeplys,FFL_GETMAXCOMPOSITEPLYS) ()
 {
@@ -806,8 +836,13 @@ INTEGER_FUNCTION(ffl_getmaxcompositeplys,FFL_GETMAXCOMPOSITEPLYS) ()
       int nPlys = static_cast<FFlPCOMP*>(p.second)->plySet.data().size();
       if (nPlys > maxPlys) maxPlys = nPlys;
     }
+
   return maxPlys;
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets composite data.
 
 INTEGER_FUNCTION(ffl_getpcompnumplys,FFL_GETPCOMPNUMPLYS) (const int& compID)
 {
@@ -821,6 +856,10 @@ INTEGER_FUNCTION(ffl_getpcompnumplys,FFL_GETPCOMPNUMPLYS) (const int& compID)
   return curComp->plySet.data().size();
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets PCOMP data.
+
 SUBROUTINE(ffl_getpcomp,FFL_GETPCOMP) (int& compID, int& nPlys, double& Z0,
                                        double* T, double* theta,
                                        double* E1, double* E2, double* NU12,
@@ -829,6 +868,7 @@ SUBROUTINE(ffl_getpcomp,FFL_GETPCOMP) (int& compID, int& nPlys, double& Z0,
 {
   ierr = -1;
   if (!ourLink) return;
+
   const AttributeMap& pComps = ourLink->getAttributes("PCOMP");
   if (pComps.empty()) return;
 
@@ -884,8 +924,7 @@ SUBROUTINE(ffl_getpcomp,FFL_GETPCOMP) (int& compID, int& nPlys, double& Z0,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get PMATSHELL data
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets PMATSHELL data.
 
 SUBROUTINE(ffl_getpmatshell,FFL_GETPMATSHELL) (const int& MID,
 					       double& E1, double& E2,
@@ -913,11 +952,10 @@ SUBROUTINE(ffl_getpmatshell,FFL_GETPMATSHELL) (const int& MID,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get shell thickness for an element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets shell thickness for an element.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getthick,FFL_GETTHICK) (double* Th, const int& iel, int& ierr)
 {
@@ -936,17 +974,17 @@ SUBROUTINE(ffl_getthick,FFL_GETTHICK) (double* Th, const int& iel, int& ierr)
 
   Th[0] = curProp->thickness.getValue();
   const int nenod = curElm->getNodeCount();
-  for (int i = 1; i < nenod; i++) Th[i] = Th[0]; // Only uniform thickness yet
+  for (int i = 1; i < nenod; i++)
+    Th[i] = Th[0]; // Only uniform thickness yet
   ierr = 0;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get the pin flags for a beam element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 11 Sep 2002 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets the pin flags for a beam element.
+//!
+//! \author Knut Morten Okstad
+//! \date 11 Sep 2002
 
 SUBROUTINE(ffl_getpinflags,FFL_GETPINFLAGS) (int& pA, int& pB,
                                              const int& iel, int& ierr)
@@ -967,11 +1005,10 @@ SUBROUTINE(ffl_getpinflags,FFL_GETPINFLAGS) (int& pA, int& pB,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get non-structural mass property for an element.
-//
-// Coded by: Tommy Stokmo Jorstad
-// Date/ver: 16 Aug 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets non-structural mass property for an element.
+//!
+//! \author Tommy Stokmo Jorstad
+//! \date 16 Aug 2001
 
 SUBROUTINE(ffl_getnsm,FFL_GETNSM) (double& Mass, const int& iel, int& ierr)
 {
@@ -988,11 +1025,10 @@ SUBROUTINE(ffl_getnsm,FFL_GETNSM) (double& Mass, const int& iel, int& ierr)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get material and cross section properties for a beam element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets material and cross section properties for a beam element.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 SUBROUTINE(ffl_getbeamsection,FFL_GETBEAMSECTION) (double* section,
 						   const int& iel, int& ierr)
@@ -1053,18 +1089,17 @@ SUBROUTINE(ffl_getbeamsection,FFL_GETBEAMSECTION) (double* section,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get global coordinates for a node.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 12 Oct 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets global coordinates for a node.
+//!
+//! \author Knut Morten Okstad
+//! \date 12 Oct 2000
 
 SUBROUTINE(ffl_getnodalcoor,FFL_GETNODALCOOR) (double& X, double& Y, double& Z,
                                                const int& inod, int& ierr)
 {
   if (!ourLink)
   {
-    std::cerr <<"ffl_getnodalcoor: Internal error, ourLink is NULL"<< std::endl;
+    std::cerr <<"ffl_getnodalcoor: FE part object not initialized"<< std::endl;
     ierr = -1;
     return;
   }
@@ -1087,11 +1122,10 @@ SUBROUTINE(ffl_getnodalcoor,FFL_GETNODALCOOR) (double& X, double& Y, double& Z,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get symmetric 6x6 mass matrix for a concentrated mass element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 13 Nov 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets the mass matrix for a concentrated mass element.
+//!
+//! \author Knut Morten Okstad
+//! \date 13 Nov 2000
 
 SUBROUTINE(ffl_getmass,FFL_GETMASS) (double* em, const int& iel, int& ndof,
 				     int& ierr)
@@ -1127,11 +1161,10 @@ SUBROUTINE(ffl_getmass,FFL_GETMASS) (double* em, const int& iel, int& ndof,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get symmetric 6x6 or 12x12 stiffness matrix for a linear spring element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 8 Mar 2002 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets the stiffness matrix for a linear spring element.
+//!
+//! \author Knut Morten Okstad
+//! \date 8 Mar 2002
 
 SUBROUTINE(ffl_getspring,FFL_GETSPRING) (double* ek, int& nedof,
                                          const int& iel, int& ierr)
@@ -1171,11 +1204,10 @@ SUBROUTINE(ffl_getspring,FFL_GETSPRING) (double* ek, int& nedof,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get element coordinate system.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 1 Oct 2010 / 2.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets an element coordinate system.
+//!
+//! \author Knut Morten Okstad
+//! \date 1 Oct 2010 / 2.0
 
 SUBROUTINE(ffl_getelcoorsys,FFL_GETELCOORSYS) (double* T, const int& iel,
 					       int& ierr)
@@ -1191,11 +1223,10 @@ SUBROUTINE(ffl_getelcoorsys,FFL_GETELCOORSYS) (double* T, const int& iel,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get stiffness coefficients for a bushing element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 28 Aug 2003 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets the stiffness coefficients for a bushing element.
+//!
+//! \author Knut Morten Okstad
+//! \date 28 Aug 2003
 
 SUBROUTINE(ffl_getbush,FFL_GETBUSH) (double* k, const int& iel, int& ierr)
 {
@@ -1212,18 +1243,18 @@ SUBROUTINE(ffl_getbush,FFL_GETBUSH) (double* k, const int& iel, int& ierr)
     return;
   }
 
-  for (int i = 0; i < 6; i++) k[i] = bush->K[i].getValue();
+  for (int i = 0; i < 6; i++)
+    k[i] = bush->K[i].getValue();
 
   ierr = 0;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get DOF-component definitions for a rigid element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 24 Jul 2002 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets the DOF-component definitions for a rigid element.
+//!
+//! \author Knut Morten Okstad
+//! \date 24 Jul 2002
 
 SUBROUTINE(ffl_getrgddofcomp,FFL_GETRGDDOFCOMP) (int* comp, const int& iel,
 						 int& ierr)
@@ -1262,22 +1293,25 @@ SUBROUTINE(ffl_getrgddofcomp,FFL_GETRGDDOFCOMP) (int* comp, const int& iel,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get component definitions and weights for a weighted average motion element.
-// If iel is -1, only return the size of the largest weight array through refC.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 12 Aug 2002 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets properties for a weighted average motion (WAVGM) element.
+//! \details The component definitions and associated weights are returned.
+//! If \a iel is -1, only the size of the largest weight array is returned
+//! through the output argument \a refC. Otherwise, the size of the weight array
+//! for the given element is returned through the output argument \a ierr.
+//!
+//! \author Knut Morten Okstad
+//! \date 12 Aug 2002
 
 SUBROUTINE(ffl_getwavgm,FFL_GETWAVGM) (int& refC, int* indC, double* weights,
                                        const int& iel, int& ierr)
 {
   if (iel < 0 && ourLink)
   {
-    int N = refC = ierr = 0;
+    refC = ierr = 0;
     for (const AttributeMap::value_type& p : ourLink->getAttributes("PWAVGM"))
-      if ((N = static_cast<FFlPWAVGM*>(p.second)->weightMatrix.getValue().size()) > refC)
-        refC = N;
+      if (FFlPWAVGM* pWAVGM = static_cast<FFlPWAVGM*>(p.second); pWAVGM)
+        if (int N = pWAVGM->weightMatrix.getValue().size(); N > refC)
+          refC = N;
     return;
   }
 
@@ -1294,11 +1328,11 @@ SUBROUTINE(ffl_getwavgm,FFL_GETWAVGM) (int& refC, int* indC, double* weights,
 
   if (FFlPWAVGM* pWAVGM = GET_ATTRIBUTE(curElm,PWAVGM); pWAVGM)
   {
-    ierr = 1;
     refC = pWAVGM->refC.getValue();
-    size_t i, N = pWAVGM->weightMatrix.getValue().size();
-    for (i = 0; i < 6; i++) indC[i] = pWAVGM->indC[i].getValue();
-    for (i = 0; i < N; i++) weights[i] = pWAVGM->weightMatrix.getValue()[i];
+    ierr = pWAVGM->weightMatrix.getValue().size();
+    for (int i = 0; i < 6; i++)
+      indC[i] = pWAVGM->indC[i].getValue();
+    memcpy(weights,pWAVGM->weightMatrix.getValue().data(),ierr*sizeof(double));
   }
   else
     ierr = 0; // No properties given - use default
@@ -1306,11 +1340,10 @@ SUBROUTINE(ffl_getwavgm,FFL_GETWAVGM) (int& refC, int* indC, double* weights,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get load set identification numbers.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 22 Feb 2008 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets load set identification numbers.
+//!
+//! \author Knut Morten Okstad
+//! \date 22 Feb 2008
 
 SUBROUTINE(ffl_getloadcases,FFL_GETLOADCASES) (int* loadCases, int& nlc)
 {
@@ -1332,11 +1365,10 @@ SUBROUTINE(ffl_getloadcases,FFL_GETLOADCASES) (int* loadCases, int& nlc)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return number of loads with the given load set id.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 2 Apr 2008 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns the number of loads with the given load set id.
+//!
+//! \author Knut Morten Okstad
+//! \date 2 Apr 2008
 
 INTEGER_FUNCTION(ffl_getnoload,FFL_GETNOLOAD) (const int& SID)
 {
@@ -1353,18 +1385,17 @@ INTEGER_FUNCTION(ffl_getnoload,FFL_GETNOLOAD) (const int& SID)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Get data for the next load with the given load set id.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 22 Feb 2008 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Gets data for the next load with the given load set id.
+//!
+//! \author Knut Morten Okstad
+//! \date 22 Feb 2008
 
 SUBROUTINE(ffl_getload,FFL_GETLOAD) (const int& SID, int& iel, int& face,
 				     double* P)
 {
   if (!ourLink)
   {
-    std::cerr <<"ffl_getload: Internal error, ourLink is NULL"<< std::endl;
+    std::cerr <<"ffl_getload:  FE part object not initialized"<< std::endl;
     iel = face = 0;
     return;
   }
@@ -1414,57 +1445,10 @@ SUBROUTINE(ffl_getload,FFL_GETLOAD) (const int& SID, int& iel, int& face,
 #ifdef FT_USE_STRAINCOAT
 
 ////////////////////////////////////////////////////////////////////////////////
-//! \brief Auxiliary function for retrieval of strain coat attributes.
+//! \brief Gets data for the next strain coat element.
 //!
 //! \author Knut Morten Okstad
 //! \date 28 May 2001
-
-static void getStrainCoatAttributes (FFlPSTRC* p, FFlPFATIGUE* pFat,
-                                     int& resSet, int& id,
-                                     double& E, double& nu, double& Z,
-                                     int& SNstd, int& SNcurve, double& SCF)
-{
-  resSet = id = 0;
-  E = nu = Z = SCF = 0.0;
-  SNstd = SNcurve = -1;
-  if (!p) return;
-
-  const std::string& name = p->name.getValue();
-  if (name == "Bottom")
-    resSet = 1;
-  else if (name == "Mid")
-    resSet = 2;
-  else if (name == "Top")
-    resSet = 3;
-
-  if (FFlPMAT* curMat = GET_ATTRIBUTE(p,PMAT); curMat)
-  {
-    id = curMat->getID();
-    E  = curMat->youngsModule.getValue();
-    nu = curMat->poissonsRatio.getValue();
-  }
-
-  if (FFlPHEIGHT* curHeight = GET_ATTRIBUTE(p,PHEIGHT); curHeight)
-    Z = curHeight->height.getValue();
-  else if (FFlPTHICKREF* curTref = GET_ATTRIBUTE(p,PTHICKREF); curTref)
-    if (FFlPTHICK* curThk = GET_ATTRIBUTE(curTref,PTHICK); curThk)
-      Z = curThk->thickness.getValue() * curTref->factor.getValue();
-
-  if (pFat)
-  {
-    SNstd = pFat->snCurveStd.getValue();
-    SNcurve = pFat->snCurveIndex.getValue();
-    SCF = pFat->stressConcentrationFactor.getValue();
-  }
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Get data for the next strain coat element.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 28 May 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
 
 SUBROUTINE(ffl_getstraincoat,FFL_GETSTRAINCOAT) (int& Id, int& nnod, int& npts,
                                                  int* nodes, int* matId,
@@ -1475,8 +1459,7 @@ SUBROUTINE(ffl_getstraincoat,FFL_GETSTRAINCOAT) (int& Id, int& nnod, int& npts,
 {
   if (!ourLink)
   {
-    std::cerr <<"ffl_getstraincoat: Internal error, ourLink is NULL"
-	      << std::endl;
+    std::cerr <<"ffl_getstraincoat: FE part object not initialized"<< std::endl;
     ierr = -1;
     return;
   }
@@ -1531,11 +1514,10 @@ SUBROUTINE(ffl_getstraincoat,FFL_GETSTRAINCOAT) (int& Id, int& nnod, int& npts,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return total number of materials for strain coat elements.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 28 June 2002 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns the total number of materials for all strain coat elements.
+//!
+//! \author Knut Morten Okstad
+//! \date 28 June 2002
 
 INTEGER_FUNCTION(ffl_getnostrcmat,FFL_GETNOSTRCMAT) ()
 {
@@ -1545,20 +1527,26 @@ INTEGER_FUNCTION(ffl_getnostrcmat,FFL_GETNOSTRCMAT) ()
     return -1;
   }
 
-  FFlAttributeBase*                              curAtt;
-  std::vector<FFlElementBase*>::const_iterator   ei;
-  std::vector<AttribData>::const_iterator        ai;
-  std::map<int,int>                              usedMat;
+  std::map<int,int> usedMat;
 
-  for (ei = ourLink->elementsBegin(); ei != ourLink->elementsEnd(); ++ei)
-    if (FFlLinkHandler::isStrainCoat(*ei) && (*ei)->doCalculations())
-      for (FFlAttributeBase* pstrc : (*ei)->getAttributes("PSTRC"))
-        for (ai = pstrc->attributesBegin(); ai != pstrc->attributesEnd(); ++ai)
-        {
-          curAtt = ai->second.getReference();
-          if (curAtt->getTypeName() == "PMAT")
-            usedMat[curAtt->getID()] ++;
-        }
+  for (ElementsCIter eit = ourLink->elementsBegin();
+       eit != ourLink->elementsEnd(); ++eit)
+
+    if (FFlLinkHandler::isStrainCoat(*eit) && (*eit)->doCalculations())
+      for (FFlAttributeBase* pstrc : (*eit)->getAttributes("PSTRC"))
+
+        for (AttribsVec::const_iterator ait = pstrc->attributesBegin();
+             ait != pstrc->attributesEnd(); ++ait)
+
+          if (FFlAttributeBase* attr = ait->second.getReference();
+              attr->getTypeName() == "PMAT")
+          {
+            if (std::map<int,int>::iterator iit = usedMat.find(attr->getID());
+                iit == usedMat.end())
+              usedMat[attr->getID()] = 1;
+            else
+              ++(iit->second);
+          }
 
   int nMat = usedMat.size();
 #ifdef FFL_DEBUG
@@ -1573,11 +1561,11 @@ INTEGER_FUNCTION(ffl_getnostrcmat,FFL_GETNOSTRCMAT) ()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return number of strain coat elements for which the calculation flag is set.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 20 Sep 2000 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns number of active strain coat elements.
+//! \details Only elements for which the calculation flag is set are considered.
+//!
+//! \author Knut Morten Okstad
+//! \date 20 Sep 2000
 
 INTEGER_FUNCTION(ffl_getnostrc,FFL_GETNOSTRC) ()
 {
@@ -1594,11 +1582,10 @@ INTEGER_FUNCTION(ffl_getnostrc,FFL_GETNOSTRC) ()
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Calculate the checksum of the loaded FE part.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 8 Jan 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Calculates the checksum of the loaded FE part.
+//!
+//! \author Knut Morten Okstad
+//! \date 8 Jan 2001
 
 SUBROUTINE(ffl_calcs,FFL_CALCS) (int& ierr)
 {
@@ -1626,11 +1613,10 @@ SUBROUTINE(ffl_calcs,FFL_CALCS) (int& ierr)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Add an integer option to the checksum.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 8 Jan 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Adds an integer option to the checksum.
+//!
+//! \author Knut Morten Okstad
+//! \date 8 Jan 2001
 
 SUBROUTINE(ffl_addcs_int,FFL_ADDCS_INT) (int& value)
 {
@@ -1640,11 +1626,10 @@ SUBROUTINE(ffl_addcs_int,FFL_ADDCS_INT) (int& value)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Add a double option to the checksum.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 8 Jan 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Adds a double option to the checksum.
+//!
+//! \author Knut Morten Okstad
+//! \date 8 Jan 2001
 
 SUBROUTINE(ffl_addcs_double,FFL_ADDCS_DOUBLE) (double& value)
 {
@@ -1654,11 +1639,10 @@ SUBROUTINE(ffl_addcs_double,FFL_ADDCS_DOUBLE) (double& value)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Return the checksum as an integer.
-//
-// Coded by: Knut Morten Okstad
-// Date/ver: 10 Jan 2001 / 1.0
-////////////////////////////////////////////////////////////////////////////////
+//! \brief Returns the checksum as an integer.
+//!
+//! \author Knut Morten Okstad
+//! \date 10 Jan 2001
 
 SUBROUTINE(ffl_getcs,FFL_GETCS) (int& cs, int& ierr)
 {

--- a/src/FFlLib/FFlUtils.C
+++ b/src/FFlLib/FFlUtils.C
@@ -42,6 +42,7 @@ bool FFl::convertMPCsToWAVGM (FFlLinkHandler* part, const FFl::MPCMap& mpcs)
 #endif
 
     size_t nRow = 0;
+    int nmndofs = 0;
     DoublesMapMap dofWeights;
     for (const std::pair<const short int,DepDOFs>& mpc : mpcGroup.second)
       if (mpc.first > 0 && mpc.first < 7)
@@ -50,16 +51,13 @@ bool FFl::convertMPCsToWAVGM (FFlLinkHandler* part, const FFl::MPCMap& mpcs)
         DoublesMap& dofWeight = dofWeights[mpc.first];
         for (const DepDOF& dof : mpc.second)
         {
+          if (dof.lDof > nmndofs) nmndofs = dof.lDof;
+          int i = std::find(nodes.begin(),nodes.end(),dof.node) - nodes.begin();
           Doubles& weights = dofWeight[dof.lDof];
           weights.resize(nodes.size()-1,0.0);
-          for (size_t iNod = 1; iNod < nodes.size(); iNod++)
-            if (dof.node == nodes[iNod])
-            {
-              weights[iNod-1] = dof.coeff;
-              break;
-            }
+          weights[i-1] = dof.coeff;
         }
-        nRow += 6; // Assuming all DOFs in the master node is referred
+        ++nRow; // Assuming all DOFs in the master node is referred
 #if FFL_DEBUG > 1
         std::cout <<"Weight matrix associated with slave dof "<< mpc.first;
         for (const std::pair<const int,Doubles>& weights : dofWeight)
@@ -75,15 +73,15 @@ bool FFl::convertMPCsToWAVGM (FFlLinkHandler* part, const FFl::MPCMap& mpcs)
     size_t indx = 1;
     size_t nMst = nodes.size() - 1;
     int indC[6] = { 0, 0, 0, 0, 0, 0 };
-    Doubles weights(nRow*nMst,0.0);
+    Doubles weights(nRow*nmndofs*nMst,0.0);
     for (const std::pair<const int,DoublesMap>& dofw : dofWeights)
     {
       refC = 10*refC + dofw.first; // Compressed slave DOFs identifier
       indC[dofw.first-1] = indx;   // Index to first weight for this slave DOF
       for (const std::pair<const int,Doubles>& dof : dofw.second)
         for (size_t j = 0; j < dof.second.size(); j++)
-          weights[indx+6*j+dof.first-2] = dof.second[j];
-      indx += 6*nMst;
+          weights[indx+nmndofs*j+dof.first-2] = dof.second[j];
+      indx += nmndofs*nMst;
     }
 
     int id = part->getNewElmID();


### PR DESCRIPTION
This fixes openfedem/fedem-solvers#49. The problem was that the reference nodes of the generated WAVGM elements always were assigned 6 nodal DOFs. But when when the model consists of solid elements only there are not rotational DOFs to couple. The solution is therefore to enforce 3 DOFs only on the reference nodes in this case.